### PR TITLE
Don't set table_data.header_info.moltra_info value to False for orbitals outside the MOLTRA range.

### DIFF
--- a/src/dcaspt2_input_generator/components/data.py
+++ b/src/dcaspt2_input_generator/components/data.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, OrderedDict as ODict
 
 from qtpy.QtGui import QColor, QIcon, QPixmap
 
@@ -33,7 +33,7 @@ class SpinorNumber:
         )
 
 
-class MoltraInfo(Dict[str, Dict[int, bool]]):
+class MoltraInfo(Dict[str, ODict[int, bool]]):
     pass
 
 

--- a/src/dcaspt2_input_generator/components/table_widget.py
+++ b/src/dcaspt2_input_generator/components/table_widget.py
@@ -2,11 +2,12 @@ import copy
 from pathlib import Path
 from typing import List
 
-from dcaspt2_input_generator.components.data import Color, MOData, SpinorNumber, colors, table_data
-from dcaspt2_input_generator.utils.utils import debug_print
 from qtpy.QtCore import Qt, Signal  # type: ignore
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QAction, QMenu, QTableWidget, QTableWidgetItem  # type: ignore
+
+from dcaspt2_input_generator.components.data import Color, MOData, SpinorNumber, colors, table_data
+from dcaspt2_input_generator.utils.utils import debug_print
 
 
 # TableWidget is the widget that displays the output data
@@ -180,7 +181,8 @@ class TableWidget(QTableWidget):
                         moltra_range[key_elem] = True
                 table_data.header_info.moltra_info[moltra_type] = moltra_range
                 idx += 2
-
+            for key in table_data.header_info.moltra_info.keys():
+                table_data.header_info.moltra_info[key] = dict(sorted(table_data.header_info.moltra_info[key].items()))
         def read_spinor_num_info(row: List[str]):
             # spinor_num info is following the format:
             # spinor_num_type1 closed int open int virtual int ...

--- a/src/dcaspt2_input_generator/components/table_widget.py
+++ b/src/dcaspt2_input_generator/components/table_widget.py
@@ -86,10 +86,6 @@ class TableWidget(QTableWidget):
                 raise ValueError(msg)
             if cur_idx[key] == 0:
                 min_idx[key] = row.mo_number
-            # Find not moltra orbitals
-            elif cur_idx[key] + 1 != row.mo_number:
-                for idx in range(cur_idx[key] + 1, row.mo_number):
-                    table_data.header_info.moltra_info[key][idx] = False
             cur_idx[row.mo_symmetry] = row.mo_number
 
         # if v is 4, it means that the number of orbitals that are not included in the output is 3=4-1
@@ -171,22 +167,17 @@ class TableWidget(QTableWidget):
                 moltra_type = row[idx]
                 moltra_range_str = row[idx + 1]
                 moltra_range = {}
-                for cnt, elem in enumerate(moltra_range_str.split(",")):
+                for elem in moltra_range_str.split(","):
                     moltra_range_elem = elem.strip()
                     if ".." in moltra_range_elem:
                         moltra_range_start, moltra_range_end = moltra_range_elem.split("..")
                         moltra_range_start = int(moltra_range_start)
                         moltra_range_end = int(moltra_range_end)
-                        if cnt == 0:
-                            for i in range(1, moltra_range_start):
-                                moltra_range[i] = False
                         for i in range(moltra_range_start, moltra_range_end + 1):
                             moltra_range[i] = True
                     else:
                         key_elem = int(moltra_range_elem)
                         moltra_range[key_elem] = True
-                        if cnt == 0:
-                            moltra_range[1:key_elem] = False
                 table_data.header_info.moltra_info[moltra_type] = moltra_range
                 idx += 2
 

--- a/src/dcaspt2_input_generator/controller/widget_controller.py
+++ b/src/dcaspt2_input_generator/controller/widget_controller.py
@@ -61,18 +61,22 @@ class WidgetController:
                 if not is_used:
                     continue
                 if start:
+                    # First used MO
                     range_str += f" {mo_num}"
                     range_start_num = mo_num
                     start = False
                 elif mo_num != prev_mo_num + 1:
                     if range_start_num == prev_mo_num:
+                        # Prev MO is alone, already added to range_str
                         range_str += f" {mo_num}"
                         range_start_num = mo_num
                     else:
+                        # Prev MO is not alone, not added to range_str yet
                         range_str += f"..{prev_mo_num} {mo_num}"
                         range_start_num = mo_num
                 prev_mo_num = mo_num
-            if search_end:
+            if search_end and range_start_num != prev_mo_num:
+                # prev_mo_num is not added to range_str
                 range_str += f"..{prev_mo_num}"
             res += range_str
 

--- a/src/dcaspt2_input_generator/controller/widget_controller.py
+++ b/src/dcaspt2_input_generator/controller/widget_controller.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from dcaspt2_input_generator.components.data import colors, table_data
 from dcaspt2_input_generator.components.table_summary import TableSummary
 from dcaspt2_input_generator.components.table_widget import TableWidget
@@ -49,31 +51,33 @@ class WidgetController:
         for k, d in table_data.header_info.moltra_info.items():
             res += f"\n {k}"
             range_str = ""
-            left = True
-            ser_end = False
-            cur_mo_num = 0
-            start_mo_num = cur_mo_num
-            for mo_num, is_used in d.items():
-                cur_mo_num = mo_num
-                if is_used:
-                    if left:
-                        if range_str == "":
-                            range_str += f" {mo_num}"
-                        else:
-                            range_str += f",{mo_num}"
-                        start_mo_num = mo_num
-                        left = False
-                        ser_end = True
-                elif ser_end:
-                    if mo_num > start_mo_num + 1:
-                        range_str += f"..{mo_num-1}"
-                    left = True
-                    ser_end = False
-            if ser_end:
-                range_str += f"..{cur_mo_num}"
+            start = True
+            prev_mo_num = 0
+            range_start_num = 0
+            search_end = False
+            sorted_d = OrderedDict(sorted(d.items()))
+            for mo_num, is_used in sorted_d.items():
+                search_end = True
+                if not is_used:
+                    continue
+                if start:
+                    range_str += f" {mo_num}"
+                    range_start_num = mo_num
+                    start = False
+                elif mo_num != prev_mo_num + 1:
+                    if range_start_num == prev_mo_num:
+                        range_str += f" {mo_num}"
+                        range_start_num = mo_num
+                    else:
+                        range_str += f"..{prev_mo_num} {mo_num}"
+                        range_start_num = mo_num
+                prev_mo_num = mo_num
+            if search_end:
+                range_str += f"..{prev_mo_num}"
             res += range_str
 
         self.table_summary.recommended_moltra.setText(f"Recommended MOLTRA setting: {res}")
 
         # Reload the input
+        self.table_summary.update()
         self.table_summary.update()

--- a/src/dcaspt2_input_generator/utils/args.py
+++ b/src/dcaspt2_input_generator/utils/args.py
@@ -12,7 +12,7 @@ class PrintVersionExitAction(argparse.Action):
             help=help,
         )
 
-    def __call__(self):
+    def __call__(self, parser, namespace, values, option_string=None):  # noqa: ARG002
         from dcaspt2_input_generator.__about__ import __version__
 
         print(f"{__version__}")


### PR DESCRIPTION
- エネルギー順に並び替えたときに不連続なインデックスが入力に渡されると、デフォルトのCAS(4,8)を上手く塗れない問題を解決
  - 不連続なインデックスが渡されると、その間のインデックスのmoltra_infoがFalseに設定されてしまうため、MOLTRAの範囲外になっていた
  - Falseに更新することをやめて解決
- 上記を解決したことによるMOLTRAの推奨指定の出力のバグを解決
- dcaspt2_input_generator -v と打つとエラーが返っていたバグを解決