### PR TITLE
Fix multi process

### DIFF
--- a/src/dcaspt2_input_generator/components/main_window.py
+++ b/src/dcaspt2_input_generator/components/main_window.py
@@ -215,7 +215,6 @@ Please update sum_dirac_dfcoef to v4.0.0 or later with `pip install -U sum_dirac
             command = create_command(
                 f"sum_dirac_dfcoef -i {file_path} -d 3 -c -o {dir_info.sum_dirac_dfcoef_path} -j {num_process}"
             )
-            print(command)
             cmd = command.split()
             self.process.start(cmd[0], cmd[1:])
             if self.process.exitCode() != 0:

--- a/src/dcaspt2_input_generator/components/main_window.py
+++ b/src/dcaspt2_input_generator/components/main_window.py
@@ -211,7 +211,7 @@ Please update sum_dirac_dfcoef to v4.0.0 or later with `pip install -U sum_dirac
                 raise Exception(msg)
 
         def run_command():
-            num_process = min(1, settings.multi_process_input.multi_process_num)
+            num_process = max(1, settings.multi_process_input.multi_process_num)
             command = create_command(
                 f"sum_dirac_dfcoef -i {file_path} -d 3 -c -o {dir_info.sum_dirac_dfcoef_path} -j {num_process}"
             )

--- a/src/dcaspt2_input_generator/components/multi_process_settings.py
+++ b/src/dcaspt2_input_generator/components/multi_process_settings.py
@@ -1,12 +1,11 @@
+import os
+
 from dcaspt2_input_generator.utils.settings import settings
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QAction, QDialog, QSpinBox, QVBoxLayout
 
 
 class MultiProcessSettings(QDialog):
-    # 質問と回答を受け取る
-    # 回答はinteger, natural number
-
     multi_process_changed = Signal()
 
     def __init__(self):
@@ -17,7 +16,7 @@ class MultiProcessSettings(QDialog):
         self.setWindowTitle("Set Process Number for sum_dirac_dfcoef calculation")
         self.resize(400, 50)
         self.multi_process_spin_box = QSpinBox()
-        self.multi_process_spin_box.setRange(1, 100)
+        self.multi_process_spin_box.setRange(1, os.cpu_count())
         self.multi_process_spin_box.setValue(settings.multi_process_input.multi_process_num)
         self.multi_process_spin_box.valueChanged.connect(self.onMultiProcessChanged)
 

--- a/src/dcaspt2_input_generator/utils/settings.py
+++ b/src/dcaspt2_input_generator/utils/settings.py
@@ -1,6 +1,7 @@
 # This script contains all functions to handle settings of this application.
 
 import json
+import os
 
 from dcaspt2_input_generator.utils.dir_info import dir_info
 
@@ -55,15 +56,17 @@ class DefaultMultiProcessInput:
         self.multi_process_num = self.get_multi_process_num()
 
     def get_multi_process_num(self) -> int:
+        num_process = 4  # default
         if dir_info.setting_file_path.exists():
             with open(dir_info.setting_file_path) as f:
                 try:
                     settings = json.load(f)
                     if "multi_process_num" in settings:
-                        return int(settings["multi_process_num"])
+                        num_process = int(settings["multi_process_num"])
                 except CustomJsonDecodeError as e:
                     raise CustomJsonDecodeError(dir_info.setting_file_path) from e
-        return 4
+        # If the number of CPU cores is less than the number of processes, use the number of CPU cores.
+        return min(os.cpu_count(), num_process)
 
 
 class Settings:


### PR DESCRIPTION
- コードの間違いで常に1プロセスで実行するようになっていたので、マルチプロセス実行できるように変更
- 100並列まで設定できるようにしたが、ユーザの論理プロセッサ数(=os.cpu_count)を最大値に設定した
  - つまりmin(100, os.cpu_count())
  - 論理プロセッサ数より多くのプロセス数で並列化してもほぼ速度向上には貢献しないため、この仕様に変更