### PR TITLE
Add DIRAC version input and delete DIRAC version checkbox

### DIFF
--- a/src/dcaspt2_input_generator/components/table_summary.py
+++ b/src/dcaspt2_input_generator/components/table_summary.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
-from dcaspt2_input_generator.utils.settings import settings
-from dcaspt2_input_generator.utils.utils import debug_print
 from qtpy.QtCore import Signal  # type: ignore
 from qtpy.QtGui import QFocusEvent, QIntValidator
-from qtpy.QtWidgets import QCheckBox, QFrame, QGridLayout, QLabel, QLineEdit, QWidget
+from qtpy.QtWidgets import QFrame, QGridLayout, QLabel, QLineEdit, QWidget
+
+from dcaspt2_input_generator.utils.settings import settings
+from dcaspt2_input_generator.utils.utils import debug_print
 
 
 class NaturalNumberInput(QLineEdit):
@@ -49,8 +50,8 @@ class NaturalNumberInput(QLineEdit):
         elif int(current_text) < self.bottom_num:
             self.setText(str(self.bottom_num))
 
-    def get_value(self):
-        return self.text()
+    def get_value(self) -> int:
+        return int(self.text())
 
     # At the end of the input, the number is validated
     def focusOutEvent(self, arg__1: QFocusEvent) -> None:
@@ -85,21 +86,6 @@ class TotsymNumberInput(NaturalNumberInput):
         self.changed.emit()
 
 
-class DIRACCheckbox(QCheckBox):
-    def __init__(self, changed: Signal):
-        super().__init__()
-        self.setChecked(settings.input.dirac_ver_21_or_later)
-        self.stateChanged.connect(self.change_state)
-        self.changed = changed
-
-    def change_state(self, state):
-        if state == 2:
-            settings.input.dirac_ver_21_or_later = True
-        else:
-            settings.input.dirac_ver_21_or_later = False
-        self.changed.emit()
-
-
 class UserInput(QGridLayout):
     changed = Signal()
 
@@ -115,15 +101,15 @@ class UserInput(QGridLayout):
         self.selectroot_label = QLabel("selectroot")
         self.selectroot_number = NaturalNumberInput(bottom_num=1, default_num=settings.input.selectroot)
         # Add checkbox
-        self.diracver_label = QLabel("Is the version of DIRAC larger than 21?")
-        self.diracver_checkbox = DIRACCheckbox(self.changed)
+        self.diracver_label = QLabel("DIRAC major version (if 21.1, type 21)")
+        self.dirac_ver_number = NaturalNumberInput(bottom_num=12, default_num=settings.input.dirac_ver)
 
         self.addWidget(self.totsym_label, 0, 0)
         self.addWidget(self.totsym_number, 0, 1)
         self.addWidget(self.selectroot_label, 0, 2)
         self.addWidget(self.selectroot_number, 0, 3)
         self.addWidget(self.diracver_label, 0, 4)
-        self.addWidget(self.diracver_checkbox, 0, 5)
+        self.addWidget(self.dirac_ver_number, 0, 5)
         self.addWidget(self.ras1_max_hole_label, 1, 0)
         self.addWidget(self.ras1_max_hole_number, 1, 1)
         self.addWidget(self.ras3_max_electron_label, 1, 2)
@@ -135,7 +121,7 @@ class UserInput(QGridLayout):
             "selectroot": self.selectroot_number.get_value(),
             "ras1_max_hole": self.ras1_max_hole_number.get_value(),
             "ras3_max_electron": self.ras3_max_electron_number.get_value(),
-            "dirac_ver_21_or_later": self.diracver_checkbox.isChecked(),
+            "dirac_ver": self.dirac_ver_number.get_value(),
         }
 
 

--- a/src/dcaspt2_input_generator/controller/widget_controller.py
+++ b/src/dcaspt2_input_generator/controller/widget_controller.py
@@ -68,8 +68,8 @@ class WidgetController:
         else:
             output += f"nocc\n{nocc['E1']}\n"
             output += "" if sum(nvcut.values()) == 0 else f"nvcut\n{nvcut['E1']}\n"
-        output += f"totsym\n{self.table_summary.user_input.totsym_number.text()}\n"
-        output += f"diracver\n{21 if self.table_summary.user_input.diracver_checkbox.isChecked() else 19}\n"
+        output += f"totsym\n{self.table_summary.user_input.totsym_number.get_value()}\n"
+        output += f"diracver\n{self.table_summary.user_input.dirac_ver_number.get_value()}\n"
         output += "end\n"
 
         # Save standard IVO input (replace active.ivo.inp)

--- a/src/dcaspt2_input_generator/utils/settings.py
+++ b/src/dcaspt2_input_generator/utils/settings.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from typing import Dict, Union
 
 from dcaspt2_input_generator.utils.dir_info import dir_info
 
@@ -18,7 +19,7 @@ class DefaultUserInput:
     selectroot: int
     ras1_max_hole: int
     ras3_max_hole: int
-    dirac_ver_21_or_later: bool
+    dirac_ver: int
 
     def __init__(self):
         # If the settings.json file exists, read the settings from the file
@@ -30,7 +31,10 @@ class DefaultUserInput:
                     self.selectroot = int(settings["selectroot"])
                     self.ras1_max_hole = int(settings["ras1_max_hole"])
                     self.ras3_max_electron = int(settings["ras3_max_electron"])
-                    self.dirac_ver_21_or_later = settings["dirac_ver_21_or_later"]
+                    self.dirac_ver = int(settings["dirac_ver"])
+                except KeyError as e:
+                    msg = f"settings.json is broken. missing key: {e}, please delete {dir_info.setting_file_path} and restart this application."
+                    raise KeyError(msg) from e
                 except CustomJsonDecodeError as e:
                     raise CustomJsonDecodeError(dir_info.setting_file_path) from e
 
@@ -71,6 +75,16 @@ class DefaultMultiProcessInput:
 
 class Settings:
     def __init__(self):
+        # Application Default Settings
+        self.default_settings: Dict[str, Union[int, str]] = {
+            "totsym": 1,
+            "selectroot": 1,
+            "ras1_max_hole": 0,
+            "ras3_max_electron": 0,
+            "dirac_ver": 23,
+            "color_theme": "default",
+            "multi_process_num": 4,
+        }
         if not dir_info.setting_file_path.exists():
             self.create_default_settings_file()
         self.input = DefaultUserInput()
@@ -78,18 +92,8 @@ class Settings:
         self.multi_process_input = DefaultMultiProcessInput()
 
     def create_default_settings_file(self):
-        # Application Default Settings
-        settings = {
-            "totsym": 1,
-            "selectroot": 1,
-            "ras1_max_hole": 0,
-            "ras3_max_electron": 0,
-            "dirac_ver_21_or_later": False,
-            "color_theme": "default",
-            "multi_process_num": 4,
-        }
         with open(dir_info.setting_file_path, mode="w") as f:
-            json.dump(settings, f, indent=4)
+            json.dump(self.default_settings, f, indent=4)
 
 
 settings = Settings()


### PR DESCRIPTION
- [このissue](https://github.com/RQC-HU/dirac_caspt2/issues/139)により、DIRAC23以降では異なる処理をしないといけないことが判明したので、DIRAC21以降かそうでないかのチェックボックスではなく、DIRACのバージョンを指定してもらうように変更
  - [DIRACのGitLabにはDIRAC12から](https://gitlab.com/dirac/dirac/-/tree/release-12)バージョンが存在していて、上記issueの結果よりDIRAC12もサポートできるようなので、DIRACのバージョンを入力する欄は、12以上の整数を入力できるようにした