### PR TITLE
Chore-manual-and-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Install
 
 ```bash
-pip install dcaspt2_input_generator
+pip install -U dcaspt2_input_generator
 ```
 
 ## Usage

--- a/src/dcaspt2_input_generator/components/table_widget.py
+++ b/src/dcaspt2_input_generator/components/table_widget.py
@@ -18,7 +18,7 @@ from qtpy.QtWidgets import QAction, QMenu, QTableWidget, QTableWidgetItem
 # 4. Change the background color of the selected cells
 # 5. Emit the color_changed signal when the background color is changed
 # Display the output data like the following:
-# gerade/ungerade    no. of spinor    energy (a.u.)    percentage 1    AO type 1    percentage 2    AO type 2    ...
+# irrep              no. of spinor    energy (a.u.)    percentage 1    AO type 1    percentage 2    AO type 2    ...
 # E1u                1                -9.631           33.333          B3uArpx      33.333          B2uArpy      ...
 # E1u                2                -9.546           50.000          B3uArpx      50.000          B2uArpy      ...
 # ...
@@ -144,7 +144,7 @@ class TableWidget(QTableWidget):
         self.update_index_info()
 
     def set_column_header_items(self):
-        header_data = ["gerade/ungerade", "no. of spinor", "energy (a.u.)"]
+        header_data = ["irrep", "no. of spinor", "energy (a.u.)"]
         init_header_len = len(header_data)
         additional_header = []
         for idx in range(init_header_len, table_data.column_max_len):
@@ -159,7 +159,7 @@ class TableWidget(QTableWidget):
     def resize_columns(self):
         self.resizeColumnsToContents()
         for idx in range(table_data.column_max_len):
-            if idx == 0:  # gerade/ungerade
+            if idx == 0:  # irrep
                 self.setColumnWidth(idx, self.columnWidth(idx) + 20)
             elif idx == 1 or idx % 2 == 0:  # no. of spinor, percentage
                 self.setColumnWidth(idx, self.columnWidth(idx) + 10)

--- a/src/dcaspt2_input_generator/dcaspt2_input_generator.py
+++ b/src/dcaspt2_input_generator/dcaspt2_input_generator.py
@@ -3,7 +3,6 @@ import sys
 
 from qtpy.QtWidgets import QApplication
 
-from dcaspt2_input_generator.utils.args import args  # noqa: F401, only import args to parse the command line arguments
 from dcaspt2_input_generator.utils.dir_info import dir_info
 
 # import qt_material


### PR DESCRIPTION
- READMEのインストールコマンドに-Uオプションを追加
- 最初のカラムのヘッダはgerade/ungeradeとしていたが、E1g,E1uではなくE1のときgerade/ungeradeという説明と合わなくなるのでirrepに変更
- dcaspt2_input_generator.pyのargsのimportが不要だったので削除