### PR TITLE
Support memory usage estimation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["sum_dirac_dfcoef>=4.3.0", "PySide6", "qtpy"]
+dependencies = ["sum_dirac_dfcoef>=4.4.0", "PySide6", "qtpy"]
 
 [project.optional-dependencies]
 dev = ["coverage[toml]>=6.5", "pytest", "black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]

--- a/src/dcaspt2_input_generator/components/data.py
+++ b/src/dcaspt2_input_generator/components/data.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Union
 from typing import OrderedDict as ODict
 
 from qtpy.QtGui import QColor, QIcon, QPixmap
@@ -46,6 +46,7 @@ class SpinorNumInfo(Dict[str, SpinorNumber]):
 class HeaderInfo:
     spinor_num_info: SpinorNumInfo = None
     moltra_info: MoltraInfo = None
+    point_group: Union[str, None] = None
     electron_number: int = 0
 
     def __post_init__(self):

--- a/src/dcaspt2_input_generator/components/main_window.py
+++ b/src/dcaspt2_input_generator/components/main_window.py
@@ -3,7 +3,7 @@ import subprocess
 from pathlib import Path
 
 from qtpy.QtCore import QProcess, QSettings, Qt
-from qtpy.QtGui import QDragEnterEvent, QDropEvent, QFont, QKeyEvent
+from qtpy.QtGui import QDragEnterEvent, QDropEvent, QKeyEvent
 from qtpy.QtWidgets import QFileDialog, QMainWindow, QMessageBox, QPushButton, QVBoxLayout, QWidget
 
 from dcaspt2_input_generator.components.data import colors, table_data
@@ -50,8 +50,8 @@ class MainWindow(QMainWindow):
         self.menu_bar.save_action_dfcoef.triggered.connect(self.save_sum_dirac_dfcoef)
 
         # Body
-        self.table_summary = TableSummary()
         self.table_widget = TableWidget()
+        self.table_summary = TableSummary()
         # Add Save button
         self.save_button = QPushButton("Save")
         self.save_button.clicked.connect(self.save_input)
@@ -284,7 +284,7 @@ Please run the sum_dirac_dfcoef program first.",
         if event.mimeData().hasText():
             event.accept()
 
-    def dropEvent(self, event="") -> None:
+    def dropEvent(self, event: QDropEvent) -> None:
         # Get the file path
         filename = event.mimeData().text()[8:]
         filepath = Path(filename).expanduser().resolve()

--- a/src/dcaspt2_input_generator/components/table_summary.py
+++ b/src/dcaspt2_input_generator/components/table_summary.py
@@ -135,17 +135,19 @@ class TableSummary(QWidget):
         self.spinor_summary = SpinorSummary()
         self.user_input = UserInput()
         self.recommended_moltra = QLabel("Recommended MOLTRA setting")
+        self.point_group = QLabel("Point Group")
 
         self.summaryLayout.addWidget(QLabel("Summary of the number of spinors"), 0, 0)
         self.summaryLayout.addLayout(self.spinor_summary, 1, 0)
         self.summaryLayout.addWidget(self.recommended_moltra, 2, 0)
+        self.summaryLayout.addWidget(self.point_group, 3, 0)
 
         line = QFrame()
         line.setFrameShape(QFrame.Shape.HLine)
         line.setFrameShadow(QFrame.Shadow.Sunken)
-        self.summaryLayout.addWidget(line, 3, 0)
+        self.summaryLayout.addWidget(line, 4, 0)
 
-        self.summaryLayout.addWidget(QLabel("User Input"), 4, 0)
-        self.summaryLayout.addLayout(self.user_input, 5, 0)
+        self.summaryLayout.addWidget(QLabel("User Input"), 5, 0)
+        self.summaryLayout.addLayout(self.user_input, 6, 0)
 
         self.setLayout(self.summaryLayout)


### PR DESCRIPTION
## Summary
- dirac_caspt2プログラムの大体の最大使用メモリ量を表示できるようになりました
  - 計算が現実的に可能そうか計算前に把握することが可能になります 
- UO2_2+ inact: 32, act: 26, sec: 860 の場合、実際の計算と比べて13MB程度のズレで最大使用メモリを予想できます
![image](https://github.com/RQC-HU/dcaspt2_input_generator/assets/103017367/189c033e-9ac6-4c39-aecb-216f14dd5a8f)
- 最大使用メモリ量を予想するために、分子の点群の情報が必要なので、sum_dirac_dfcoefのバージョンを点群情報を出力する [v4.4.0以降](https://github.com/RQC-HU/sum_dirac_dfcoef/releases/tag/v4.4.0)に更新(pyproject.toml)
  - v4.3.0まではサポートするが、点群情報が得られないので、最大使用メモリ量は表示されません

## Implementation

- 点群情報が得られたら最大使用メモリ量を計算します
  - 使用メモリ量のほとんどが2電子積分の保持用途なので、関連するallocatableな変数のサイズを計算します
  - 点群がC1のときだけ2電子積分が複素数になり、allocateのサイズが増えるので、そこに注意してメモリ量を計算します
https://github.com/RQC-HU/dcaspt2_input_generator/blob/ee3c94700d8a649078651ec337d62f64b7fb18ea/src/dcaspt2_input_generator/controller/widget_controller.py#L162-L173

- 最大使用メモリ量を計算したら、GBまでの適切な単位に変換して使用メモリ量を文字列化します
https://github.com/RQC-HU/dcaspt2_input_generator/blob/ee3c94700d8a649078651ec337d62f64b7fb18ea/src/dcaspt2_input_generator/controller/widget_controller.py#L83-L97

- 使用メモリ量を画面に反映します
https://github.com/RQC-HU/dcaspt2_input_generator/blob/ee3c94700d8a649078651ec337d62f64b7fb18ea/src/dcaspt2_input_generator/controller/widget_controller.py#L174-L176


- 点群情報が得られなかった場合は、情報が得られなかった旨のメッセージと使用メモリ量を計算できないことを伝える
https://github.com/RQC-HU/dcaspt2_input_generator/blob/ee3c94700d8a649078651ec337d62f64b7fb18ea/src/dcaspt2_input_generator/controller/widget_controller.py#L177-L179