### PR TITLE
Fix tag name sed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Get the tag name
         id: get_tag_name
         run: |
-          echo "tag_name=$(echo "${{ github.head_ref }}" | sed -e 's/release-v//')" >> $GITHUB_OUTPUT
+          echo "tag_name=$(echo "${{ github.head_ref }}" | sed -e 's/release-//')" >> $GITHUB_OUTPUT
       - name: Create tag
         run: |
           git tag ${{ steps.get_tag_name.outputs.tag_name }}


### PR DESCRIPTION
- [publish.yml](https://github.com/RQC-HU/dcaspt2_input_generator/blob/main/.github/workflows/publish.yml)で sed -e 's/release-v//' としてリリース用のタグを作っていたが、そうすると [release-pr.yml](https://github.com/RQC-HU/dcaspt2_input_generator/blob/main/.github/workflows/release-pr.yml) で作っているtagであるvx.y.zのタグが使われず、x.y.zがリリースタグとして使われてしまっていたので、vx.y.zを使うように変更した
  - 具体的には sed -e 's/release-//' とするとvx.y.zの文字列が得られる