### PR TITLE
Support moltra scheme

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,1 @@
-!Ar_Ar.out
-!x2c_uo2_238.out
+!*.out

--- a/data/dirac23_scheme6_N2.out
+++ b/data/dirac23_scheme6_N2.out
@@ -1,0 +1,2844 @@
+  ** interface to 64-bit integer MPI enabled **
+
+DIRAC master    (DESKTOP-1C7AGIU) starts by allocating       64000000 r*8 words (   0.477 GB) of memory
+DIRAC nodes 1 to 7 starts by allocating            64000000 r*8 words (   0.477 GB) of memory
+DIRAC nodes 1 to 7 to allocate at most           2147483648 r*8 words (  16.000 GB) of memory
+DIRAC master    (DESKTOP-1C7AGIU) to allocate at most      2147483648 r*8 words (  16.000 GB) of memory
+ 
+Note: maximum allocatable memory for master+nodes can be set by -aw (MW)/-ag (GB) flags in pam
+ 
+ *******************************************************************************
+ *                                                                             *
+ *                                O U T P U T                                  *
+ *                                   from                                      *
+ *                                                                             *
+ *                   @@@@@    @@   @@@@@     @@@@     @@@@@                    *
+ *                   @@  @@        @@  @@   @@  @@   @@                        *
+ *                   @@  @@   @@   @@@@@    @@@@@@   @@                        *
+ *                   @@  @@   @@   @@ @@    @@  @@   @@                        *
+ *                   @@@@@    @@   @@  @@   @@  @@    @@@@@                    *
+ *                                                                             *
+ *                                                                             *
+ %}ZS)S?$=$)]S?$%%>SS$%S$ZZ6cHHMHHHHHHHHMHHM&MHbHH6$L/:<S///</:|/:|:/::!:.::--:%
+ $?S$$%$$$$?%?$(SSS$SSSHMMMMMMMMMMMMMMMMMM6H&6S&SH&&k?6$r~::://///::::::.:::-::$
+ (%?)Z??$$$(S%$>$)S6HMMMMMMMMMMMMMMMMMMMMMMR6M]&&$6HR$&6(i::::::|i|:::::::-:-::(
+ $S?$$)$?$%?))?S/]#MMMMMMMMMMMMMMMMMMMMMMMMMMHM1HRH9R&$$$|):?:/://|:/::/:/.::.:$
+ SS$%%?$%((S)?Z[6MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM&HF$$&/)S?<~::!!:::::::/:-:|.S
+ SS%%%%S$%%%$$MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHHHHHHM>?/S/:/:::`:/://:/::-::S
+ ?$SSSS?%SS$)MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM/4?:S:/:::/:::/:/:::.::?
+ S$(S?S$%(?$HMMMMMMMMMMMMMMMMM#&7RH99MMMMMMMMMMMMMMMMMMHHHd$/:::::/::::::-//.:.S
+ (?SS(%)S&HMMMMMMMMMMMMMMMMM#S|///???$9HHMMMMMMMMMDSZ&1S/?</>?~:///::|/!:/-:-:.(
+ $S?%?<H(MMMMMMMMMMMMMMMMR?`. :.:`::<>:``?/*?##*)$:/>       `((%://::/:::::/::/$
+ S$($$)HdMMMMMMMMMMMMMMMP: . `   `  `    `      `-            `Z<:>?::/:::::|:iS
+ c%%%&HMMMMMMMMMMMMMMMM6:                                      `$%)>%%</>!:::::c
+ S?%/MMMMMMMMMMMMMMMMMMH-                                        /ZSS>?:?~:;/::S
+ $SZ?MMMMMMMMMMMMMMMMMH?.                                        \"&((/?//?|:::$
+ $%$%&MMMMMMMMMMMMMMMMM:.                                          ?%/S:</::/::$
+ ($?}&HMMMMMMMMMMMMMMMM>:                                          $%%<?/i:|i::(
+ Z$($&MMMMMMMMMMMMMMMMHk(:.  . -                                   .S/\?\?/!:/:Z
+ (??$<HMMMMMMMMMMMMMMMFk|:   -.-.                                  :%/%/(:/:ii|(
+ SZ(S?]MMMMMMMMMMMMMMHS?:- -  ::.:                                  |/S:</::?||S
+ $%)$$(MMMMMMMMMMMMMMR):`:. :.:::`,,/bcokb/_                       :S?%?|~:/:/:$
+ %$$%$)[[?$?MMMMMMMMMM: :.:-.::::$7?<&7&MMMMMMM#/           _ .. ..:</?:(:/::::%
+ $$$?Z?HHH~|/MMMMMMMMM/`.-.:.:/:%%%%?dHMMMMMMMMMMH?,-   .,bMMMM6//./i~/~:<:::/:$
+ $($S$M//::S?ZHMMMMMH/:.`:::.:/%S/&MMHMMMMMMMMRM&><   ,HMMMMMMMF  :::?:///:|:::$
+ )[$S$S($|_i:#>::*H&?/::.::/:\"://:?>>`:&HMHSMMMM$:`-   MMHMMMMHHT .)i/?////::/)
+ $$[$$>$}:dHH&$$--?S::-:.:::--/-:``./::>%Zi?)&/?`:.`   `H?$T*\" `  /%?>%:)://ii$
+ $&=&/ZS}$RF<:?/-.|%r/:::/:/:`.-.-..|::S//!`\"``          >??:    `SS<S:)!/////$
+ Z&]>b[Z(Z?&%:::../S$$:>:::i`.`. `-.`  `                         ,>%%%:>/>/!|:/Z
+ $$&/F&1$c$?>:>?/,>?$$ZS/::/:-: ...                              |S?S)S?<~:::::$
+ &$&$&$k&>>|?<:<?((/$[/?)i~/:/. - -                              S?:%%%?/:::/::&
+ =[/Z[[Fp[MMH$>?Z&S$$$/$S///||..-           -.-                  /((S$:%<:///:/=
+ $&>1MHHMMMM6M9MMMM$Z$}$S%/:::.`.            .:/,,,dcb>/:.       ((SSSS%:)!//i|$
+ MMMMMMMMMMMR&&RRRHR&&($(?:|i::-             .:%&S&$[&H&``     ../>%;/?>??:<::>M
+ MMMMMMMMMMMMS/}S$&&H&[$SS//:::.:.   . . .v</Jq1&&D]&M&<,      :/::/?%%)S>?://:M
+ MMMMMMMMMMMM?}$/$$kMM&&$(%/?//:..`.  .|//1d/`://?*/*/\"` `     .:/(SS$%(S%)):%M
+ MMMMMMMMMMMM(}$$>&&MMHR#$S%%:?::.:|-.`:;&&b/D/$p=qpv//b/~`   :/~~%%??$=$)Z$S+;M
+ MMMMMMMMMMMM[|S$$Z1]MMMMD[$?$:>)/::: :/?:``???bD&{b<<-`     .,:/)|SS(}Z/$$?/<SM
+ MMMMMMMMMMMM||$)&7k&MMMMH9]$$??Z%|!/:i::`  `` .             SS?SS?Z/]1$/&$c/$SM
+ MMMMMMMMMMMM| -?>[&]HMMMMMMMH1[/7SS(?:/..-` ::/Sc,/_,     _<$?SS%$S/&c&&$&>//<M
+ MMMMMMMMMMMMR  `$&&&HMM9MMMMMMM&&c$%%:/:/:.:.:/\?\?/\    _MMHk/7S/]dq&1S<&&></M
+ MMMMMMMMMMMMM?  :&96MHMMMMMMMMMMMHHk[S%(<<:// `         ,MMMMMMM&/Z6H]DkH]1$&&M
+ MMMMMMMMMMMMMD    99H9HMMMMMMMMMMMMMMMb&%$<:i.:....    .MMMMMMMMM6HHHRH&H&H1SFM
+ MMMMMMMMMMMMMM|   `?HMMMMMMMMMMMMMMMMMMMHk6k&>$&Z$/?_.bHMMMMMMMMMMM&6HRM9H6]ZkM
+ MMMMMMMMMMMMMMM/    `TMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHMH6RH&R6&M
+ MMMMMMMMMMMMMMMM    -|?HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMFHH6HMD&&M
+ MMMMMMMMMMMMMMMMk  ..:~?9MMMMMMMMMMMMM#`:MMMMMMMMMMMMMMMMMMMMMMMMMMMMM9MHkR6&FM
+ MMMMMMMMMMMMMMMMM/  .-!:%$ZHMMMMMMMMMR` dMMMMMMMMMMMMMMMMMMMMMMMMMMMMM9MRMHH9&M
+ MMMMMMMMMMMMMMMMMML,:.-|::/?&&MMMMMM` .MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHRMH&&6M
+ MMMMMMMMMMMMMMMMMMMc%>/:::i<:SMMMMMMHdMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHHM&969kM
+ MMMMMMMMMMMMMMMMMMMMSS/$$/(|HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHH&HH&M
+ MMMMMMMMMMMMMMMMMMMM6S/?/MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMR96H1DR1M
+ MMMMMMMMMMMMMMMMMMMMM&$MHMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMHMH691&&M
+ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&R&9ZM
+ MMMMMMMMMMMMMMMMMMMMMMMMMRHMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&96][6M
+ MMMMMMMMMMMMMMMMMMMMMMMMp?:MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM96HH1][FM
+ MMMMMMMMMMMMMMMMMMMMMMMM> -HMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMH&1k&$&M
+ *******************************************************************************
+ *                                                                             *
+ *         =========================================================           *
+ *                     Program for Atomic and Molecular                        *
+ *          Direct Iterative Relativistic All-electron Calculations            *
+ *         =========================================================           *
+ *                                                                             *
+ *                                                                             *
+ *    Written by:                                                              *
+ *                                                                             *
+ *    Radovan Bast             UiT The Arctic University of      Norway        *
+ *    Andre S. P. Gomes        CNRS/Universite de Lille          France        *
+ *    Trond Saue               Universite Toulouse III           France        *
+ *    Lucas Visscher           Vrije Universiteit Amsterdam      Netherlands   *
+ *    Hans Joergen Aa. Jensen  University of Southern Denmark    Denmark       *
+ *                                                                             *
+ *    with contributions from:                                                 *
+ *                                                                             *
+ *    Ignacio Agustin Aucar    CONICET/Northeastern University   Argentina     *
+ *    Vebjoern Bakken          University of Oslo                Norway        *
+ *    Chima Chibueze           Vrije Universiteit Amsterdam      Netherlands   *
+ *    Joel Creutzberg          University of Southern Denmark    Denmark       *
+ *    Kenneth G. Dyall         Schrodinger, Inc., Portland       USA           *
+ *    Sebastien Dubillard      University of Strasbourg          France        *
+ *    Ulf Ekstroem             University of Oslo                Norway        *
+ *    Ephraim Eliav            University of Tel Aviv            Israel        *
+ *    Thomas Enevoldsen        University of Southern Denmark    Denmark       *
+ *    Elke Fasshauer           University of Tubingen            Germany       *
+ *    Timo Fleig               Universite Toulouse III           France        *
+ *    Olav Fossgaard           UiT The Arctic University of      Norway        *
+ *    Loic Halbert             Universite de Lille               France        *
+ *    Erik D. Hedegaard        University of Southern Denmark    Denmark       *
+ *    Trygve Helgaker          University of Oslo                Norway        *
+ *    Benjamin Helmich-Paris   Max Planck Institute f. Coal Res. Germany       *
+ *    Johan Henriksson         Linkoeping University             Sweden        *
+ *    Martin van Horn          Universite Toulouse III           France        *
+ *    Miroslav Ilias           Matej Bel University              Slovakia      *
+ *    Christoph R. Jacob       TU Braunschweig                   Germany       *
+ *    Stefan Knecht            Algorithmiq Ltd / ETH Zuerich     Finland/CH    *
+ *    Stanislav Komorovsky     Slovak Academy of Sciences        Slovakia      *
+ *    Ossama Kullie            University of Kassel              Germany       *
+ *    Jon K. Laerdahl          University of Oslo                Norway        *
+ *    Christoffer V. Larsen    University of Southern Denmark    Denmark       *
+ *    Yoon Sup Lee             KAIST, Daejeon                    South Korea   *
+ *    Nanna Holmgaard List     Stockholm Inst. of Technology     Sweden        *
+ *    Huliyar S. Nataraj       BME/Budapest Univ. Tech. & Econ.  Hungary       *
+ *    Malaya Kumar Nayak       Bhabha Atomic Research Centre     India         *
+ *    Patrick Norman           Stockholm Inst. of Technology     Sweden        *
+ *    Andreas Nyvang           Aarhus University                 Denmark       *
+ *    Malgorzata Olejniczak    University of Warsaw              Poland        *
+ *    Jeppe Olsen              Aarhus University                 Denmark       *
+ *    Jogvan Magnus H. Olsen   University of Southern Denmark    Denmark       *
+ *    Anastasios Papadopoulos  Max Planck Institute f. Coal Res. Germany       *
+ *    Young Choon Park         KAIST, Daejeon                    South Korea   *
+ *    Jesper K. Pedersen       University of Southern Denmark    Denmark       *
+ *    Markus Pernpointner      University of Heidelberg          Germany       *
+ *    Johann V. Pototschnig    Technical University Graz         Austria       *
+ *    Roberto Di Remigio       EuroCC National Competence Centre Sweden        *
+ *    Michal Repisky           UiT The Arctic University of      Norway        *
+ *    Kenneth Ruud             UiT The Arctic University of      Norway        *
+ *    Pawel Salek              Stockholm Inst. of Technology     Sweden        *
+ *    Bernd Schimmelpfennig    Karlsruhe Institute of Technology Germany       *
+ *    Bruno Senjean            CNRS/Universite de Montpellier    France        *
+ *    Avijit Shee              University of Berkeley            USA           *
+ *    Jetze Sikkema            Vrije Universiteit Amsterdam      Netherlands   *
+ *    Ayaki Sunaga             Kyoto University                  Japan         *
+ *    Andreas J. Thorvaldsen   UiT The Arctic University of      Norway        *
+ *    Joern Thyssen            University of Southern Denmark    Denmark       *
+ *    Joost N. P. van Stralen  Vrije Universiteit Amsterdam      Netherlands   *
+ *    Marta L. Vidal           Cardiff University                UK            *
+ *    Sebastien Villaume       Linkoeping University             Sweden        *
+ *    Olivier Visser           University of Groningen           Netherlands   *
+ *    Toke Winther             University of Southern Denmark    Denmark       *
+ *    Shigeyoshi Yamamoto      Chukyo University                 Japan         *
+ *    Xiang Yuan               Universite de Lille               France        *
+ *                                                                             *
+ *    For more information about the DIRAC code see http://diracprogram.org    *
+ *                                                                             *
+ *    This is an experimental code. The authors accept no responsibility       *
+ *    for the performance of the code or for the correctness of the results.   *
+ *                                                                             *
+ *    This program is free software; you can redistribute it and/or            *
+ *    modify it under the terms of the GNU Lesser General Public               *
+ *    License version 2.1 as published by the Free Software Foundation.        *
+ *                                                                             *
+ *    If results obtained with this code are published, an                     *
+ *    appropriate citation would be:                                           *
+ *                                                                             *
+ *    DIRAC, a relativistic ab initio electronic structure program,            *
+ *    Release DIRAC23 (2023), written by                                       *
+ *    R. Bast, A. S. P. Gomes, T. Saue, L. Visscher, and H. J. Aa. Jensen,     *
+ *    with contributions from I. A. Aucar, V. Bakken, C. Chibueze,             *
+ *    J. Creutzberg, K. G. Dyall, S. Dubillard, U. Ekstroem, E. Eliav,         *
+ *    T. Enevoldsen, E. Fasshauer, T. Fleig, O. Fossgaard, L. Halbert,         *
+ *    E. D. Hedegaard, T. Helgaker, J. Henriksson, M. van Horn, M. Ilias,      *
+ *    Ch. R. Jacob, S. Knecht, S. Komorovsky, O. Kullie, J. K. Laerdahl,       *
+ *    C. V. Larsen, Y. S. Lee, N. H. List, H. S. Nataraj, M. K. Nayak,         *
+ *    P. Norman, A. Nyvang, M. Olejniczak, J. Olsen, J. M. H. Olsen,           *
+ *    A. Papadopoulos, Y. C. Park, J. K. Pedersen, M. Pernpointner,            *
+ *    J. V. Pototschnig, R. Di Remigio, M. Repisky, K. Ruud, P. Salek,         *
+ *    B. Schimmelpfennig, B. Senjean, A. Shee, J. Sikkema, A. Sunaga,          *
+ *    A. J. Thorvaldsen, J. Thyssen, J. N. P. van Stralen, M. L. Vidal,        *
+ *    S. Villaume, O. Visser, T. Winther, S. Yamamoto and X. Yuan              *
+ *    (see http://diracprogram.org).                                           *
+ *                                                                             *
+ *    as well as our reference paper: J. Chem. Phys. 152 (2020) 204104.        *
+ *                                                                             *
+ *******************************************************************************
+
+
+Version information
+-------------------
+
+Branch        | release-23
+Commit hash   | 400e5caf4
+Commit author | Hans Jørgen Aagaard Jensen
+Commit date   | Wed Feb 22 13:50:08 2023 +0000
+
+
+Configuration and build information
+-----------------------------------
+
+Who compiled             | noda
+Compiled on server       | DESKTOP-1C7AGIU
+Operating system         | Linux-5.15.146.1-microsoft-standard-WSL2
+CMake version            | 3.22.1
+CMake generator          | Unix Makefiles
+CMake build type         | release
+Configuration time       | 2024-03-12 14:18:37.476269
+Fortran compiler         | /home/noda/software/openmpi/4.1.6/intel-oneapi/2023.2.1/bin/mpifort
+Fortran compiler version | 2021.10
+Fortran compiler flags   |  -w -assume byterecl -g -traceback -DVAR_IFORT  -qopenmp -i8
+C compiler               | /home/noda/software/openmpi/4.1.6/intel-oneapi/2023.2.1/bin/mpicc
+C compiler version       | 2021.10
+C compiler flags         |  -g -wd981 -wd279 -wd383 -wd1572 -wd177  -qopenmp
+C++ compiler             | /home/noda/software/openmpi/4.1.6/intel-oneapi/2023.2.1/bin/mpicxx
+C++ compiler version     | 2021.10.0
+C++ compiler flags       |  -Wno-unknown-pragmas  -qopenmp
+Static linking           | False
+64-bit integers          | True
+MPI parallelization      | True
+MPI launcher             | /opt/intel/oneapi/mpi/2021.10.0/bin/mpiexec
+Math libraries           | unknown
+Builtin BLAS library     | OFF
+Builtin LAPACK library   | OFF
+Explicit libraries       | unknown
+Compile definitions      | HAVE_MKL_BLAS;HAVE_MKL_LAPACK;HAVE_MPI;HAVE_OPENMP;VAR_MPI;VAR_MPI2;USE_MPI_MOD_F90;SYS_LINUX;PRG_DIRAC;INT_STAR8;INSTALL_WRKMEM=64000000;HAS_PCMSOLVER;BUILD_GEN1INT;HAS_PELIB;HAS_STIELTJES;MOD_LAO_REARRANGED;MOD_MCSCF_spinfree;MOD_ESR;MOD_KRCC;MOD_SRDFT
+
+EXACORR dependencies
+--------------------
+Exatensor source repo    | unknown
+Exatensor git hash       | unknown
+Exatensor configuration  | unknown
+
+
+ LAPACK integer*4/8 selftest passed
+ Selftest of ISO_C_BINDING Fortran - C/C++ interoperability PASSED
+ MPI selftest passed with MPI_INTEGER of the size 8 bytes
+
+
+ * openMP activated,  max # processes, max # threads, current # threads:       16       5       1
+
+Execution time and host
+-----------------------
+
+ 
+     Date and time (Linux)  : Mon Apr 15 01:46:21 2024
+     Host name              : DESKTOP-1C7AGIU                         
+
+ * Opening checkpoint file 
+    - New checkpoint file created
+
+
+Contents of the input file
+--------------------------
+
+**DIRAC                                                                                             
+.TITLE                                                                                              
+N2                                                                                                  
+.WAVE FUNCTION                                                                                      
+.ANALYZE                                                                                            
+.4INDEX                                                                                             
+.PROPERTIES                                                                                         
+**INTEGRALS                                                                                         
+.NUCMOD                                                                                             
+1                                                                                                   
+*READIN                                                                                             
+.UNCONTRACT                                                                                         
+**HAMILTONIAN                                                                                       
+.X2C                                                                                                
+**WAVE FUNCTIONS                                                                                    
+.SCF                                                                                                
+.RELCCSD                                                                                            
+*SCF                                                                                                
+.MAXITR                                                                                             
+ 100                                                                                                
+.EVCCNV                                                                                             
+ 1.0E-10                                                                                            
+.ERGCNV                                                                                             
+ 1.0E-10                                                                                            
+**ANALYZE                                                                                           
+.MULPOP                                                                                             
+.PRIVEC                                                                                             
+*PRIVEC                                                                                             
+.VECPRI                                                                                             
+all                                                                                                 
+all                                                                                                 
+**PROPERTIES                                                                                        
+.RHONUC                                                                                             
+**GENERAL                                                                                           
+.PCMOUT                                                                                             
+**MOLTRA                                                                                            
+.ACTIVE                                                                                             
+all                                                                                                 
+all                                                                                                 
+.SCHEME                                                                                             
+6                                                                                                   
+*END OF                                                                                             
+
+
+Contents of the molecule file
+-----------------------------
+
+DIRAC                                                                                               
+                                                                                                    
+                                                                                                    
+C   1              A                                                                                
+       7.    2                                                                                      
+N       0.0000000000        0.0000000000        0.0000000000                                        
+N2      0.0000000000        0.0000000000        1.0000000000                                        
+LARGE BASIS STO-3G                                                                                  
+FINISH                                                                                              
+
+
+    **************************************************************************
+    *********************************** N2 ***********************************
+    **************************************************************************
+
+ Jobs in this run:
+   * Wave function
+   * Analysis
+   * Properties
+   * Transformation to Molecular Spinor basis
+
+
+    **************************************************************************
+    ************************** General DIRAC set-up **************************
+    **************************************************************************
+
+   CODATA Recommended Values of the Fundamental Physical Constants: 2018  
+             Peter J. Mohr, David B. Newell and Barry N. Taylor           
+         Reviews of Modern Physics, Vol. 93, 025010 (2021)                
+ * The speed of light :        137.0359992
+ * Running in two-component mode
+ * Parallel run with 7 slaves.
+ * Direct evaluation of the following two-electron integrals:
+   - LL-integrals
+ * Spherical transformation embedded in MO-transformation
+   for large components
+ * Transformation to scalar RKB basis embedded in
+   MO-transformation for small components
+ * Thresholds for linear dependence:
+   Large components:   1.00D-06
+   Small components:   1.00D-08
+ * MO-coefficients written to formatted file DFPCMO
+ * General print level   :   0
+
+
+    *************************************************************************
+    ****************** Output from HERMIT input processing ******************
+    *************************************************************************
+
+ Default print level:        1
+ Nuclear model requested in input: Point charge.
+
+ Two-electron integrals not calculated.
+
+
+ Ordinary (field-free non-relativistic) Hamiltonian integrals not calculated.
+
+
+
+ Changes of defaults for *READIN
+ -------------------------------
+
+
+ Uncontracted basis forced, irrespective of basis input file.
+
+
+
+   ***************************************************************************
+   ****************** Output from MOLECULE input processing ******************
+   ***************************************************************************
+
+
+
+  Title Cards
+  -----------
+
+                                                                          
+                                                                          
+
+  Coordinates are entered in Angstroms and converted to atomic units.
+          - Conversion factor : 1 bohr = 0.52917721 A
+
+
+
+                     SYMADD: Detection of molecular symmetry
+                     ---------------------------------------
+
+ Symmetry test threshold:  5.00E-06
+
+    The molecule has been centered at center of mass
+
+ Symmetry point group found: D(oo,h)        
+
+ The following symmetry elements were found: X  Y  Z  
+
+
+  Symmetry Operations
+  -------------------
+
+  Symmetry operations: 3
+
+
+
+                          SYMGRP:Point group information
+                          ------------------------------
+
+Full group is:  D(oo,h)        
+Represented as: D2h
+
+   * The point group was generated by:
+
+      Reflection in the yz-plane
+      Reflection in the xz-plane
+      Reflection in the xy-plane
+
+   * Group multiplication table
+
+        |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+   -----+----------------------------------------
+     E  |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+    C2z | C2z   E   C2x  C2y  Oxy   i   Oyz  Oxz
+    C2y | C2y  C2x   E   C2z  Oxz  Oyz   i   Oxy
+    C2x | C2x  C2y  C2z   E   Oyz  Oxz  Oxy   i 
+     i  |  i   Oxy  Oxz  Oyz   E   C2z  C2y  C2x
+    Oxy | Oxy   i   Oyz  Oxz  C2z   E   C2x  C2y
+    Oxz | Oxz  Oyz   i   Oxy  C2y  C2x   E   C2z
+    Oyz | Oyz  Oxz  Oxy   i   C2x  C2y  C2z   E 
+
+   * Character table
+
+        |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+   -----+----------------------------------------
+    Ag  |   1    1    1    1    1    1    1    1
+    B3u |   1   -1   -1    1   -1    1    1   -1
+    B2u |   1   -1    1   -1   -1    1   -1    1
+    B1g |   1    1   -1   -1    1    1   -1   -1
+    B1u |   1    1   -1   -1   -1   -1    1    1
+    B2g |   1   -1    1   -1    1   -1    1   -1
+    B3g |   1   -1   -1    1    1   -1   -1    1
+    Au  |   1    1    1    1   -1   -1   -1   -1
+
+   * Direct product table
+
+        | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+   -----+----------------------------------------
+    Ag  | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+    B3u | B3u  Ag   B1g  B2u  B2g  B1u  Au   B3g
+    B2u | B2u  B1g  Ag   B3u  B3g  Au   B1u  B2g
+    B1g | B1g  B2u  B3u  Ag   Au   B3g  B2g  B1u
+    B1u | B1u  B2g  B3g  Au   Ag   B3u  B2u  B1g
+    B2g | B2g  B1u  Au   B3g  B3u  Ag   B1g  B2u
+    B3g | B3g  Au   B1u  B2g  B2u  B1g  Ag   B3u
+    Au  | Au   B3g  B2g  B1u  B1g  B2u  B3u  Ag 
+
+
+                            **************************
+                            *** Output from DBLGRP ***
+                            **************************
+
+   * Two fermion irreps:  E1g  E1u
+   * Real group. NZ = 1
+   * Direct product decomposition:
+          E1g x E1g : Ag  + B1g + B2g + B3g
+          E1u x E1g : Au  + B1u + B2u + B3u
+          E1u x E1u : Ag  + B1g + B2g + B3g
+
+
+                                 Spinor structure
+                                 ----------------
+
+
+   * Fermion irrep no.: 1            * Fermion irrep no.: 2
+
+      La  |  Ag (1)  B1g(2)  |                La  |  Au (1)  B1u(2)  |
+      Sa  |  Au (1)  B1u(2)  |                Sa  |  Ag (1)  B1g(2)  |
+      Lb  |  B2g(3)  B3g(4)  |                Lb  |  B2u(3)  B3u(4)  |
+      Sb  |  B2u(3)  B3u(4)  |                Sb  |  B2g(3)  B3g(4)  |
+
+
+                              Quaternion symmetries
+                              ---------------------
+
+    Rep  T(+)
+    -----------------------------
+    Ag   1
+    B3u  k
+    B2u  j
+    B1g  i
+    B1u  i
+    B2g  j
+    B3g  k
+    Au   1
+
+  Nuclear repulsion energy                       :     25.929683334247 Hartree
+
+  Nuclear contribution to electric dipole moment :    0.000000000000    0.000000000000    0.000000000000 a.u.;  origin (0,0,0)
+
+
+  Atoms and basis sets
+  --------------------
+
+  Number of atom types :    1
+  Total number of atoms:    2
+
+  label    atoms   charge   prim    cont     basis   
+  ----------------------------------------------------------------------
+  N2          2       7      15      15      L  - [6s3p|6s3p]                                                    
+  ----------------------------------------------------------------------
+                             30      30      L  - large components
+  ----------------------------------------------------------------------
+  total:      2      14      30      30
+
+  Threshold for integrals (to be written to file):  1.00D-15
+
+
+  References for the basis sets
+  -----------------------------
+
+  Atom type   1
+   Elements      Contraction                       References                     
+   H - He: (3s)         -> [1s]       W.J. Hehre, R.F. Stewart and J.A. Pople,    
+   Li - Ne: (6s,3p)     -> [2s,1p]    J. Chem. Phys. 2657 (1969).                 
+   Na - Ar: (9s,6p)     -> [3s,2p]    W.J. Hehre, R. Ditchfield, R.F. Stewart,    
+                                      J.A. Pople, J. Chem. Phys.  2769 (1970).    
+   K,Ca - : (12s,9p)    -> [4s,3p]    W.J. Pietro, B.A. Levy, W.J. Hehre and R.F. 
+   Ga - Kr                            Stewart, Inorg. Chem. 19, 2225 (1980).      
+   Sc - Zn: (12s,9p,3d) -> [4s,3p,1d] W.J. Pietro and W.J. Hehre, J. Comp. Chem.  
+   Y - Cd: (15s,12p,6d) -> [5s,4p,2d] 4, 241 (1983).                              
+  ***********************************************************************         
+
+
+  Cartesian Coordinates (bohr)
+  ----------------------------
+
+  Total number of coordinates:  6
+
+
+   1   N2   1   x      0.0000000000
+   2            y      0.0000000000
+   3            z      0.9448630623
+
+   4   N2   2   x      0.0000000000
+   5            y      0.0000000000
+   6            z     -0.9448630623
+
+
+
+  Cartesian coordinates in XYZ format (Angstrom)
+  ----------------------------------------------
+
+    2
+ 
+N2     0.0000000000   0.0000000000   0.5000000000
+N2     0.0000000000   0.0000000000  -0.5000000000
+
+
+  Symmetry Coordinates
+  --------------------
+
+  Number of coordinates in each symmetry:     1    1    1    0    1    1    1    0
+
+
+  Symmetry  Ag ( 1)
+
+    1   N2    z    [  3  -    6 ]/2
+
+
+  Symmetry  B3u( 2)
+
+    2   N2    x    [  1  +    4 ]/2
+
+
+  Symmetry  B2u( 3)
+
+    3   N2    y    [  2  +    5 ]/2
+
+
+  Symmetry  B1u( 5)
+
+    4   N2    z    [  3  +    6 ]/2
+
+
+  Symmetry  B2g( 6)
+
+    5   N2    x    [  1  -    4 ]/2
+
+
+  Symmetry  B3g( 7)
+
+    6   N2    y    [  2  -    5 ]/2
+
+
+   Interatomic separations (in Angstroms):
+   ---------------------------------------
+
+            N2 1        N2 2
+
+   N2 1    0.000000
+   N2 2    1.000000    0.000000
+
+
+
+
+  Bond distances (angstroms):
+  ---------------------------
+
+                  atom 1     atom 2                           distance
+                  ------     ------                           --------
+  bond distance:    N2 2       N2 1                           1.000000
+
+
+
+   Nuclear repulsion energy                          :   25.929683334247 Hartree
+
+                       * Total mass:    28.006148 amu
+                       * Natural abundance:  99.261 %
+
+
+* Center-of-mass coordinates (a.u.):       0.000000000000000   0.000000000000000   0.000000000000000
+* Center-of-mass coordinates (A)   :       0.000000000000000   0.000000000000000   0.000000000000000
+
+
+                                GETLAB: AO-labels
+                                -----------------
+
+   * Large components:    8
+     1  L N2  1 s        2  L N2  2 s        3  L N2  1 px       4  L N2  1 py       5  L N2  1 pz       6  L N2  2 px  
+     7  L N2  2 py       8  L N2  2 pz  
+   * Small components:    0
+
+
+
+                                GETLAB: SO-labels
+                                -----------------
+
+   * Large components:    8
+     1  L Ag N2 s        2  L Ag N2 pz       3  L B3uN2 px       4  L B2uN2 py       5  L B1uN2 s        6  L B1uN2 pz  
+     7  L B2gN2 px       8  L B3gN2 py  
+   * Small components:    0
+
+
+
+  Symmetry Orbitals
+  -----------------
+
+  Number of orbitals in each symmetry:            9     3     3     0     9     3     3     0
+  Number of large orbitals in each symmetry:      9     3     3     0     9     3     3     0
+  Number of small orbitals in each symmetry:      0     0     0     0     0     0     0     0
+
+* Large component functions
+
+  Symmetry  Ag ( 1)
+
+        6 functions:    N2 s   1+2
+        3 functions:    N2 pz  1-2
+
+  Symmetry  B3u( 2)
+
+        3 functions:    N2 px  1+2
+
+  Symmetry  B2u( 3)
+
+        3 functions:    N2 py  1+2
+
+  Symmetry  B1u( 5)
+
+        6 functions:    N2 s   1-2
+        3 functions:    N2 pz  1+2
+
+  Symmetry  B2g( 6)
+
+        3 functions:    N2 px  1-2
+
+  Symmetry  B3g( 7)
+
+        3 functions:    N2 py  1-2
+
+
+   ***************************************************************************
+   *************************** Hamiltonian defined ***************************
+   ***************************************************************************
+
+
+ One-electron operator origins:
+ - General operator origin (a.u.)       :   0.000000000000000   0.000000000000000   0.000000000000000
+ - Magnetic gauge origin (a.u.)         :   0.000000000000000   0.000000000000000   0.000000000000000
+ - Dipole (and multipole) origin (a.u.) :   0.000000000000000   0.000000000000000   0.000000000000000
+  - BSS with properties !
+ * Print level:    0
+ * Exact-Two-Component (X2C) Hamiltonian
+   Reference: 
+    M. Ilias and T. Saue:
+    "Implementation of an infinite-order two-component relativistic Hamiltonian 
+    by a simple one-step transformation." 
+    J. Chem. Phys., 126 (2007) 064102.
+   additional reference for the new X2C module:
+    S. Knecht and T. Saue:
+    manuscript in preparation, Strasbourg 2010.
+
+ * Running in two-component mode
+ * Default integral flags passed to all modules
+   - LL-integrals:     1
+   - LS-integrals:     0
+   - SS-integrals:     0
+   - GT-integrals:     0
+===========================================================================
+   Set-up for AMFI/RELSCF calculations
+===========================================================================
+  ...no reading under "*AMFI  ", thus default settings
+ * AMFI   code print level:    0
+ * RELSCF code print level:    0
+ * RELSCF maximum number of iterations:   50
+ * All AMFI mean-field summations are on neutral individual atoms.
+ * order of AMFI contributions to the X2C Hamiltonian:  2
+  --> adding spin-same orbit MFSSO2 terms.
+
+
+    **************************************************************************
+    ************************** Wave function module **************************
+    **************************************************************************
+
+ Wave function types requested (in input order):
+     HF        
+     RELCCSD   
+
+ Wave function jobs in execution order (expanded):
+ * Hartree-Fock calculation
+ * Run RELCCSD code
+
+ * Initial Automatic occupation based on:
+   Total charge of atoms =  14
+   Charge of molecule    =   0
+   i.e. no. of electrons =  14
+===========================================================================
+ *SCF: Set-up for Hartree-Fock calculation:
+===========================================================================
+ * Number of fermion irreps: 2
+ * Charge of molecule : 0
+ * Sum of atomic potentials used for start guess
+ * General print level   :   0
+
+ ***** INITIAL TRIAL SCF FUNCTION *****
+ * Trial vectors read from CHECKPOINT
+ * Scaling of active-active block correction to open shell Fock operator    0.500000
+   to improve convergence (default value).
+
+ ***** SCF CONVERGENCE CRITERIA *****
+ * Convergence on total energy.
+   Desired convergence:1.000D-10
+   Allowed convergence:1.000D-10
+
+ ***** CONVERGENCE CONTROL *****
+ * Fock matrix constructed using differential density matrix
+    with optimal parameter.
+ * DIIS (in MO basis)
+ * DIIS will be activated when convergence reaches : 1.00D+20
+   - Maximum size of B-matrix:   10
+ * Damping of Fock matrix when DIIS is not activated. 
+   Weight of old matrix    : 0.250
+ * Maximum number of SCF iterations  :  100
+ * No quadratic convergent Hartree-Fock
+ * DHF occupation is allowed to change during SCF cycles.
+ * Contributions from 2-electron integrals to Fock matrix:
+   LL-integrals.
+    ---> this is default setting from Hamiltonian input
+ * NB!!! No e-p rotations in 2nd order optimization.
+ ***** OUTPUT CONTROL *****
+ * Only electron eigenvalues written out.
+===========================================================================
+ **RELCC: Set-up for Coupled Cluster calculations
+===========================================================================
+
+
+   ***************************************************************************
+   ***************************** Analysis module *****************************
+   ***************************************************************************
+
+ Jobs in this run:
+ * Write vectors
+ * Mulliken population analysis
+===========================================================================
+ VECINP: Vector print
+===========================================================================
+ * Coefficients written in SO-basis
+ * Vector print:
+    - Orbitals in fermion ircop E1g :all                                                                     
+    - Orbitals in fermion ircop E1u :all                                                                     
+ * Only large component coefficients written out.
+===========================================================================
+ POPINP: Mulliken population analysis
+===========================================================================
+ * Gross populations
+ * Label definitions based on SO-labels
+ * Number of spinors analyzed:
+    - All occupied orbitals in fermion ircop E1g
+    - All occupied orbitals in fermion ircop E1u
+ * Print level:    0
+
+
+   ***************************************************************************
+   ***************************** Property module *****************************
+   ***************************************************************************
+
+ * Print level:   0
+ * Input label: **PROPE
+ * Properties calculated for the following wave functions:
+     1: DHF 
+ These initial settings of center and origins might be changed later:
+ * Operator center (a.u.):      0.0000000000      0.0000000000      0.0000000000
+ * Gauge origin    (a.u.):      0.0000000000      0.0000000000      0.0000000000
+ * Dipole origin   (a.u.):      0.0000000000      0.0000000000      0.0000000000
+ * Perform 4c->2c picture change transformation of the four-component property operators
+===========================================================================
+ Electronic density at nuclei
+===========================================================================
+===========================================================================
+ TRPINP: Property integral transformation
+===========================================================================
+ * Print level:    0
+ *The following operators will be transformed:
+    1  XDIPLEN              B3u     T+
+...........................................................................
+      Operator type DIAGONAL : scalar operator
+      Labels and factors     : XDIPLEN  +00+     1.0000000000000 (real)     
+...........................................................................
+    2  YDIPLEN              B2u     T+
+...........................................................................
+      Operator type DIAGONAL : scalar operator
+      Labels and factors     : YDIPLEN  +00+     1.0000000000000 (real)     
+...........................................................................
+    3  ZDIPLEN              B1u     T+
+...........................................................................
+      Operator type DIAGONAL : scalar operator
+      Labels and factors     : ZDIPLEN  +00+     1.0000000000000 (real)     
+...........................................................................
+---------------------------------------------------------------------------
+
+
+
+===========================================================================
+ TRAINP: Set-up for index transformation
+===========================================================================
+
+ * General print level   :   0
+ * Electronic orbitals only.
+ * Total active space.
+    Fermion ircop:E1g
+    all                                                                     
+    Fermion ircop:E1u
+    all                                                                     
+
+ * Set-up for 2-index transformation
+ * LS Integrals not included in core Fock-matrix
+ * SS Integrals not included in core Fock-matrix
+ * Active spaces:
+    Fermion ircop:E1g
+    - Index  1:  all                                                                     
+    - Index  2:  all                                                                     
+    Fermion ircop:E1u
+    - Index  1:  all                                                                     
+    - Index  2:  all                                                                     
+
+ * Set-up for 4-index transformation
+ * Following scheme      :   6
+ - write half-transformed integrals (ij|rs) to disk
+ - sorting of intermediate 1HT integrals is disabled
+ * Screening threshold :1.00E-14
+ * MO integral threshold :1.00E-14
+ * LS Integrals not transformed.
+ * SS Integrals not transformed.
+ * Gaunt Integrals not transformed.
+ * Active spaces:
+    Fermion ircop:E1g
+    - Index  1:  all                                                                     
+    - Index  2:  all                                                                     
+    - Index  3:  all                                                                     
+    - Index  4:  all                                                                     
+    Fermion ircop:E1u
+    - Index  1:  all                                                                     
+    - Index  2:  all                                                                     
+    - Index  3:  all                                                                     
+    - Index  4:  all                                                                     
+
+
+ ********************************************************************************
+ *************************** Input consistency checks ***************************
+ ********************************************************************************
+
+
+
+    *************************************************************************
+    ************************ End of input processing ************************
+    *************************************************************************
+
+
+
+   ***************************************************************************
+   ****************** Output from MOLECULE input processing ******************
+   ***************************************************************************
+
+
+
+  Title Cards
+  -----------
+
+                                                                          
+                                                                          
+
+  Coordinates are entered in Angstroms and converted to atomic units.
+          - Conversion factor : 1 bohr = 0.52917721 A
+
+
+
+                     SYMADD: Detection of molecular symmetry
+                     ---------------------------------------
+
+ Symmetry test threshold:  5.00E-06
+
+    The molecule has been centered at center of mass
+
+ Symmetry point group found: D(oo,h)        
+
+ The following symmetry elements were found: X  Y  Z  
+
+
+  Symmetry Operations
+  -------------------
+
+  Symmetry operations: 3
+
+
+
+                          SYMGRP:Point group information
+                          ------------------------------
+
+Full group is:  D(oo,h)        
+Represented as: D2h
+
+   * The point group was generated by:
+
+      Reflection in the yz-plane
+      Reflection in the xz-plane
+      Reflection in the xy-plane
+
+   * Group multiplication table
+
+        |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+   -----+----------------------------------------
+     E  |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+    C2z | C2z   E   C2x  C2y  Oxy   i   Oyz  Oxz
+    C2y | C2y  C2x   E   C2z  Oxz  Oyz   i   Oxy
+    C2x | C2x  C2y  C2z   E   Oyz  Oxz  Oxy   i 
+     i  |  i   Oxy  Oxz  Oyz   E   C2z  C2y  C2x
+    Oxy | Oxy   i   Oyz  Oxz  C2z   E   C2x  C2y
+    Oxz | Oxz  Oyz   i   Oxy  C2y  C2x   E   C2z
+    Oyz | Oyz  Oxz  Oxy   i   C2x  C2y  C2z   E 
+
+   * Character table
+
+        |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
+   -----+----------------------------------------
+    Ag  |   1    1    1    1    1    1    1    1
+    B3u |   1   -1   -1    1   -1    1    1   -1
+    B2u |   1   -1    1   -1   -1    1   -1    1
+    B1g |   1    1   -1   -1    1    1   -1   -1
+    B1u |   1    1   -1   -1   -1   -1    1    1
+    B2g |   1   -1    1   -1    1   -1    1   -1
+    B3g |   1   -1   -1    1    1   -1   -1    1
+    Au  |   1    1    1    1   -1   -1   -1   -1
+
+   * Direct product table
+
+        | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+   -----+----------------------------------------
+    Ag  | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+    B3u | B3u  Ag   B1g  B2u  B2g  B1u  Au   B3g
+    B2u | B2u  B1g  Ag   B3u  B3g  Au   B1u  B2g
+    B1g | B1g  B2u  B3u  Ag   Au   B3g  B2g  B1u
+    B1u | B1u  B2g  B3g  Au   Ag   B3u  B2u  B1g
+    B2g | B2g  B1u  Au   B3g  B3u  Ag   B1g  B2u
+    B3g | B3g  Au   B1u  B2g  B2u  B1g  Ag   B3u
+    Au  | Au   B3g  B2g  B1u  B1g  B2u  B3u  Ag 
+
+
+                            **************************
+                            *** Output from DBLGRP ***
+                            **************************
+
+   * Two fermion irreps:  E1g  E1u
+   * Real group. NZ = 1
+   * Direct product decomposition:
+          E1g x E1g : Ag  + B1g + B2g + B3g
+          E1u x E1g : Au  + B1u + B2u + B3u
+          E1u x E1u : Ag  + B1g + B2g + B3g
+
+
+                                 Spinor structure
+                                 ----------------
+
+
+   * Fermion irrep no.: 1            * Fermion irrep no.: 2
+
+      La  |  Ag (1)  B1g(2)  |                La  |  Au (1)  B1u(2)  |
+      Sa  |  Au (1)  B1u(2)  |                Sa  |  Ag (1)  B1g(2)  |
+      Lb  |  B2g(3)  B3g(4)  |                Lb  |  B2u(3)  B3u(4)  |
+      Sb  |  B2u(3)  B3u(4)  |                Sb  |  B2g(3)  B3g(4)  |
+
+
+                              Quaternion symmetries
+                              ---------------------
+
+    Rep  T(+)
+    -----------------------------
+    Ag   1
+    B3u  k
+    B2u  j
+    B1g  i
+    B1u  i
+    B2g  j
+    B3g  k
+    Au   1
+
+  Nuclear repulsion energy                       :     25.929683334247 Hartree
+
+  Nuclear contribution to electric dipole moment :    0.000000000000    0.000000000000    0.000000000000 a.u.;  origin (0,0,0)
+
+
+  Atoms and basis sets
+  --------------------
+
+  Number of atom types :    1
+  Total number of atoms:    2
+
+  label    atoms   charge   prim    cont     basis   
+  ----------------------------------------------------------------------
+  N2          2       7      15      15      L  - [6s3p|6s3p]                                                    
+  ----------------------------------------------------------------------
+                             30      30      L  - large components
+                             78      78      S  - small components
+  ----------------------------------------------------------------------
+  total:      2      14     108     108
+
+  Cartesian basis used.
+  Threshold for integrals (to be written to file):  1.00D-15
+
+
+  References for the basis sets
+  -----------------------------
+
+  Atom type   1
+   Elements      Contraction                       References                     
+   H - He: (3s)         -> [1s]       W.J. Hehre, R.F. Stewart and J.A. Pople,    
+   Li - Ne: (6s,3p)     -> [2s,1p]    J. Chem. Phys. 2657 (1969).                 
+   Na - Ar: (9s,6p)     -> [3s,2p]    W.J. Hehre, R. Ditchfield, R.F. Stewart,    
+                                      J.A. Pople, J. Chem. Phys.  2769 (1970).    
+   K,Ca - : (12s,9p)    -> [4s,3p]    W.J. Pietro, B.A. Levy, W.J. Hehre and R.F. 
+   Ga - Kr                            Stewart, Inorg. Chem. 19, 2225 (1980).      
+   Sc - Zn: (12s,9p,3d) -> [4s,3p,1d] W.J. Pietro and W.J. Hehre, J. Comp. Chem.  
+   Y - Cd: (15s,12p,6d) -> [5s,4p,2d] 4, 241 (1983).                              
+  ***********************************************************************         
+
+
+  Cartesian Coordinates (bohr)
+  ----------------------------
+
+  Total number of coordinates:  6
+
+
+   1   N2   1   x      0.0000000000
+   2            y      0.0000000000
+   3            z      0.9448630623
+
+   4   N2   2   x      0.0000000000
+   5            y      0.0000000000
+   6            z     -0.9448630623
+
+
+
+  Cartesian coordinates in XYZ format (Angstrom)
+  ----------------------------------------------
+
+    2
+ 
+N2     0.0000000000   0.0000000000   0.5000000000
+N2     0.0000000000   0.0000000000  -0.5000000000
+
+
+  Symmetry Coordinates
+  --------------------
+
+  Number of coordinates in each symmetry:     1    1    1    0    1    1    1    0
+
+
+  Symmetry  Ag ( 1)
+
+    1   N2    z    [  3  -    6 ]/2
+
+
+  Symmetry  B3u( 2)
+
+    2   N2    x    [  1  +    4 ]/2
+
+
+  Symmetry  B2u( 3)
+
+    3   N2    y    [  2  +    5 ]/2
+
+
+  Symmetry  B1u( 5)
+
+    4   N2    z    [  3  +    6 ]/2
+
+
+  Symmetry  B2g( 6)
+
+    5   N2    x    [  1  -    4 ]/2
+
+
+  Symmetry  B3g( 7)
+
+    6   N2    y    [  2  -    5 ]/2
+
+
+   Interatomic separations (in Angstroms):
+   ---------------------------------------
+
+            N2 1        N2 2
+
+   N2 1    0.000000
+   N2 2    1.000000    0.000000
+
+
+
+
+  Bond distances (angstroms):
+  ---------------------------
+
+                  atom 1     atom 2                           distance
+                  ------     ------                           --------
+  bond distance:    N2 2       N2 1                           1.000000
+
+
+
+   Nuclear repulsion energy                          :   25.929683334247 Hartree
+
+                       * Total mass:    28.006148 amu
+                       * Natural abundance:  99.261 %
+
+
+* Center-of-mass coordinates (a.u.):       0.000000000000000   0.000000000000000   0.000000000000000
+* Center-of-mass coordinates (A)   :       0.000000000000000   0.000000000000000   0.000000000000000
+
+
+                      Nuclear contribution to dipole moments
+                      --------------------------------------
+
+                    All dipole components are zero by symmetry
+
+
+                       Generating Lowdin canonical matrix:
+                       -----------------------------------
+
+   L   Ag    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.38E-02
+   L   B2g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.27E+00
+   L   B3g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.27E+00
+   S   B3u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.12E-01
+   S   B2u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.12E-01
+   S   B1u   * Deleted:          3(Proj:          3, Lindep:          0) Smin: 0.83E-02
+   S   Au    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.38E+00
+   L   B3u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.49E+00
+   L   B2u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.49E+00
+   L   B1u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.33E-02
+   S   Ag    * Deleted:          3(Proj:          3, Lindep:          0) Smin: 0.98E-02
+   S   B1g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.76E+00
+   S   B2g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.11E-01
+   S   B3g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.11E-01
+
+                   *********************************************************************
+                   ***   Entering the Exact-Two-Component (X2C) interface in DIRAC   ***
+                   ***                                                               ***
+                   *** library version:  1.2 (August  2013)                          ***
+                   ***                                                               ***
+                   *** authors:          - Stefan Knecht                             ***
+                   ***                   - Trond Saue                                ***
+                   *** contributors:     - Hans Joergen Aagaard Jensen               ***
+                   ***                   - Michal Repisky                            ***
+                   ***                   - Miroslav Ilias                            ***
+                   *** features:         - X2C                                       ***
+                   ***                   - X2C-atomic/fragment (X2C-LU)              ***
+                   ***                   - X2C-spinfree                              ***
+                   ***                   - X2C-molecular-mean-field (X2Cmmf)         ***
+                   ***                                                               ***
+                   ***                      Universities of                          ***
+                   ***     Zuerich, Toulouse, Odense, Banska Bystrica and Tromsoe    ***
+                   ***                                                               ***
+                   *** contact: stefan.knecht@gmail.com                              ***
+                   *********************************************************************
+
+
+                   *** chosen path in X2C module: molecular X2C (with spin-orbit contributions)      
+
+
+                                Output from AMFIIN
+                                ------------------
+
+
+  *** number of unique nuclei (from file MNF.INP): 1
+
+  *** calculate AMFI for atom type 1 with atomic charge     7
+  *** number of nuclei with identical atom type:   2
+   unique nuclei index: 1
+  *** file with AMFI integrals for this center: AOPROPER_MNF.7.1    
+
+
+                         ATOMIC NO-PAIR SO-MF CODE starts
+                         --------------------------------
+
+   Douglas-Kroll type operators 
+  charge on the calculated atom:  0
+  Mean-field summation for electrons #:   7
+    ...electronic occupation of  N: [He]2s^2 2p^3             
+ ****  Written to the file TOSCF for "relscf" ****
+        charge:  7.000
+      nprimit:   6  3  0  0
+   closed sh.:   2  0  0  0
+     open sh.:   0  3  0  0
+
+
+                       *** PROGRAM AT34 - ALLIANT - @V ***
+                       -----------------------------------
+
+
+      SYMMETRY SPECIES            S       P       D       F
+      NUMBER OF BASIS FUNCTIONS:  6       3
+      NUMBER OF CLOSED SHELLS  :  2       0
+      OPEN SHELL OCCUPATION    :  0       3
+  ### SCF ITERATIONS           ###
+  ### NON-RELATIVISTIC APPROX. ###
+    1. iteration,  total energy:             0.000000000000
+    2. iteration,  total energy:           -53.548451424857
+    3. iteration,  total energy:           -53.791155464594
+    4. iteration,  total energy:           -53.802664264963
+    5. iteration,  total energy:           -53.803208786848
+    6. iteration,  total energy:           -53.803559989285
+    7. iteration,  total energy:           -53.803588799104
+    8. iteration,  total energy:           -53.803591190020
+    9. iteration,  total energy:           -53.803591315598
+   10. iteration,  total energy:           -53.803591399345
+   11. iteration,  total energy:           -53.803591406205
+   12. iteration,  total energy:           -53.803591406775
+   13. iteration,  total energy:           -53.803591405547
+   14. iteration,  total energy:           -53.803591406825
+   14. iteration,  total energy:           -53.803591406827
+  ### NON-RELATIVISTIC APPROX. ###
+        14      -0.5380359141D+02      -0.1062284820D+03       0.5242489060D+02      -0.2026298592D+01
+  ### SCF ITERATIONS           ###
+  ### EV APPROX.               ###
+    1. iteration,  total energy:           -53.824824002053
+    2. iteration,  total energy:           -53.824992121491
+    3. iteration,  total energy:           -53.824992300791
+    4. iteration,  total energy:           -53.824992307572
+    5. iteration,  total energy:           -53.824992306650
+    6. iteration,  total energy:           -53.824992308126
+    7. iteration,  total energy:           -53.824992308144
+    8. iteration,  total energy:           -53.824992308146
+    8. iteration,  total energy:           -53.824992308146
+  ### EV  OPERATOR RESULT      ###
+         8      -0.5382499231D+02      -0.1063012156D+03       0.5247622334D+02      -0.2025702478D+01
+      *** AMFIIN: ADDING nucleus    1 with charge   7 to the BSSn Hamiltonian.
+      *** AMFIIN: ADDING nucleus    2 with charge   7 to the BSSn Hamiltonian.
+
+                   *********************************************************************
+                   ***               X2C transformation ended properly.              ***
+                   ***          Calculation continues in two-component mode.         ***
+                   *********************************************************************
+
+ >>> CPU  time used in mk_h2c is   0.14 seconds
+ >>> WALL time used in mk_h2c is   0.15 seconds
+
+  Coordinates are entered in Angstroms and converted to atomic units.
+          - Conversion factor : 1 bohr = 0.52917721 A
+
+
+ The following symmetry elements were found: X  Y  Z  
+
+
+                      Nuclear contribution to dipole moments
+                      --------------------------------------
+
+                    All dipole components are zero by symmetry
+
+
+                       Generating Lowdin canonical matrix:
+                       -----------------------------------
+
+   L   Ag    * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.38E-02
+   L   B2g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.27E+00
+   L   B3g   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.27E+00
+   L   B3u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.49E+00
+   L   B2u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.49E+00
+   L   B1u   * Deleted:          0(Proj:          0, Lindep:          0) Smin: 0.33E-02
+
+
+                                Output from LINSYM
+                                ------------------
+
+
+ Parity   MJ  Functions(total) Functions(LC)
+
+ Functions(SC)
+     1    1/2         12           12            0
+     1   -3/2          3            3            0
+    -1    1/2         12           12            0
+    -1   -3/2          3            3            0
+
+
+      **********************************************************************
+      ************************* Orbital dimensions *************************
+      **********************************************************************
+
+                                   Irrep 1 Irrep 2   Sum
+No. of electronic orbitals (NESH):    15      15      30
+No. of positronic orbitals (NPSH):     0       0       0
+Total no. of orbitals      (NORB):    15      15      30
+ >>> CPU  time used in PAMSET is   0.20 seconds
+ >>> WALL time used in PAMSET is   0.23 seconds
+
+
+ *******************************************************************************
+ *********************** X2C relativistic HF calculation ***********************
+ *******************************************************************************
+
+
+*** INFO *** No trial vectors found.
+ Using sum of fitted atomic potentials as start potential.
+
+ Reference: S. Lehtola, L. Visscher, E. Engel,  J. Chem. Phys. 152 (2020) 144105. (small GRASP fit)
+
+
+########## START ITERATION NO.   1 ##########   Mon Apr 15 01:46:21 2024
+
+
+* AUTOCC( 0) : Initial occupation:
+
+ * Closed shell SCF calculation with    14 electrons in
+       3 orbitals in Fermion irrep 1 and    4 orbitals in Fermion irrep 2
+E_HOMO...E_LUMO, symmetry 1:                                  3  -0.55882    4  -0.19897
+E_HOMO...E_LUMO, symmetry 2:                                 19  -0.63817   20   0.43596
+
+=> Calculating sum of orbital energies
+It.    1    -39.44752440752      0.00D+00  0.00D+00  0.00D+00               0.00546100s   Atom. scrpot   Mon Apr 15
+
+########## START ITERATION NO.   2 ##########   Mon Apr 15 01:46:21 2024
+
+
+* GETGAB: label "GABAO1XX" not found; calling GABGEN.
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    0.00%    0.00%    0.00%    0.00%   0.04734302s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -0.47837    4   0.36129
+E_HOMO...E_LUMO, symmetry 2:                                 19  -0.51472   20   0.88900
+>>> Total wall time:  0.05326295s, and total CPU time :  0.05324300s
+
+########## END ITERATION NO.   2 ##########   Mon Apr 15 01:46:21 2024
+
+It.    2    -107.5940669415      6.81D+01 -1.81D+00  1.26D+00               0.05326295s   LL             Mon Apr 15
+
+########## START ITERATION NO.   3 ##########   Mon Apr 15 01:46:21 2024
+
+    3 *** Differential density matrix. DCOVLP     = 0.9441
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    0.00%    0.00%    0.00%    0.00%   0.01965499s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -0.60643    4   0.25707
+E_HOMO...E_LUMO, symmetry 2:                                 19  -0.64243   20   0.83811
+>>> Total wall time:  0.02504897s, and total CPU time :  0.02503600s
+
+########## END ITERATION NO.   3 ##########   Mon Apr 15 01:46:21 2024
+
+It.    3    -107.7193954912      1.25D-01 -3.88D-01  1.71D-01   DIIS   2    0.02504897s   LL             Mon Apr 15
+
+########## START ITERATION NO.   4 ##########   Mon Apr 15 01:46:21 2024
+
+    4 *** Differential density matrix. DCOVLP     = 0.9873
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    0.00%    0.00%    0.00%    0.00%   0.02420306s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -0.59748    4   0.26636
+E_HOMO...E_LUMO, symmetry 2:                                 19  -0.63263   20   0.84385
+>>> Total wall time:  0.02863407s, and total CPU time :  0.02863300s
+
+########## END ITERATION NO.   4 ##########   Mon Apr 15 01:46:21 2024
+
+It.    4    -107.7231068204      3.71D-03  6.27D-02  1.68D-02   DIIS   3    0.02863407s   LL             Mon Apr 15
+
+########## START ITERATION NO.   5 ##########   Mon Apr 15 01:46:21 2024
+
+    5 *** Differential density matrix. DCOVLP     = 0.9974
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    0.00%    0.00%    0.00%    0.00%   0.01956201s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -0.59798    4   0.26628
+E_HOMO...E_LUMO, symmetry 2:                                 19  -0.63277   20   0.84396
+>>> Total wall time:  0.02427793s, and total CPU time :  0.02427700s
+
+########## END ITERATION NO.   5 ##########   Mon Apr 15 01:46:21 2024
+
+It.    5    -107.7231546332      4.78D-05 -5.72D-03  1.84D-03   DIIS   4    0.02427793s   LL             Mon Apr 15
+
+########## START ITERATION NO.   6 ##########   Mon Apr 15 01:46:21 2024
+
+    6 *** Differential density matrix. DCOVLP     = 0.9993
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    0.00%    0.00%    0.00%    0.00%   0.01870298s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -0.59798    4   0.26631
+E_HOMO...E_LUMO, symmetry 2:                                 19  -0.63274   20   0.84397
+>>> Total wall time:  0.02340794s, and total CPU time :  0.02340900s
+
+########## END ITERATION NO.   6 ##########   Mon Apr 15 01:46:21 2024
+
+It.    6    -107.7231555376      9.04D-07  1.11D-04  1.33D-04   DIIS   5    0.02340794s   LL             Mon Apr 15
+
+########## START ITERATION NO.   7 ##########   Mon Apr 15 01:46:21 2024
+
+    7 *** Differential density matrix. DCOVLP     = 1.0000
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    0.00%    0.00%    0.00%    0.00%   0.01886702s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -0.59798    4   0.26631
+E_HOMO...E_LUMO, symmetry 2:                                 19  -0.63274   20   0.84397
+>>> Total wall time:  0.02330899s, and total CPU time :  0.02330800s
+
+########## END ITERATION NO.   7 ##########   Mon Apr 15 01:46:21 2024
+
+It.    7    -107.7231555434      5.77D-09 -1.21D-05  1.61D-05   DIIS   6    0.02330899s   LL             Mon Apr 15
+
+########## START ITERATION NO.   8 ##########   Mon Apr 15 01:46:21 2024
+
+    8 *** Differential density matrix. DCOVLP     = 1.0000
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    0.00%    0.00%    0.00%    0.00%   0.01925397s
+E_HOMO...E_LUMO, symmetry 1:                                  3  -0.59798    4   0.26631
+E_HOMO...E_LUMO, symmetry 2:                                 19  -0.63274   20   0.84397
+>>> Total wall time:  0.02395105s, and total CPU time :  0.02395100s
+
+########## END ITERATION NO.   8 ##########   Mon Apr 15 01:46:21 2024
+
+It.    8    -107.7231555435      1.02D-10  1.71D-06  8.92D-07   DIIS   7    0.02395105s   LL             Mon Apr 15
+
+########## START ITERATION NO.   9 ##########   Mon Apr 15 01:46:21 2024
+
+    9 *** Differential density matrix. DCOVLP     = 1.0000
+SCR        scr.thr.    Step1    Step2  Coulomb  Exchange   WALL-time
+SOfock:LL  1.00D-12    0.00%    0.10%    0.00%    0.00%   0.01896501s
+>>> Total wall time:  0.01936221s, and total CPU time :  0.01936200s
+
+########## END ITERATION NO.   9 ##########   Mon Apr 15 01:46:21 2024
+
+It.    9    -107.7231555435      2.84D-13 -1.11D-07  1.23D-07   DIIS   7    0.01936221s   LL             Mon Apr 15
+
+
+                                   SCF - CYCLE
+                                   -----------
+
+* Convergence on total energy.
+  Desired convergence :1.000D-10
+  Allowed convergence:1.000D-10
+
+* ERGVAL - convergence in total energy
+* FCKVAL - convergence in maximum change in total Fock matrix
+* EVCVAL - convergence in error vector (gradient)
+--------------------------------------------------------------------------------------------------------------------------------
+           Energy               ERGVAL    FCKVAL    EVCVAL      Conv.acc    CPU          Integrals   Time stamp
+--------------------------------------------------------------------------------------------------------------------------------
+It.    1    -39.44752440752      0.00D+00  0.00D+00  0.00D+00               0.00546100s   Atom. scrpot   Mon Apr 15
+It.    2    -107.5940669415      6.81D+01 -1.81D+00  1.26D+00               0.05326295s   LL             Mon Apr 15
+It.    3    -107.7193954912      1.25D-01 -3.88D-01  1.71D-01   DIIS   2    0.02504897s   LL             Mon Apr 15
+It.    4    -107.7231068204      3.71D-03  6.27D-02  1.68D-02   DIIS   3    0.02863407s   LL             Mon Apr 15
+It.    5    -107.7231546332      4.78D-05 -5.72D-03  1.84D-03   DIIS   4    0.02427793s   LL             Mon Apr 15
+It.    6    -107.7231555376      9.04D-07  1.11D-04  1.33D-04   DIIS   5    0.02340794s   LL             Mon Apr 15
+It.    7    -107.7231555434      5.77D-09 -1.21D-05  1.61D-05   DIIS   6    0.02330899s   LL             Mon Apr 15
+It.    8    -107.7231555435      1.02D-10  1.71D-06  8.92D-07   DIIS   7    0.02395105s   LL             Mon Apr 15
+It.    9    -107.7231555435      2.84D-13 -1.11D-07  1.23D-07   DIIS   7    0.01936221s   LL             Mon Apr 15
+--------------------------------------------------------------------------------------------------------------------------------
+* Convergence after    9 iterations.
+* Average elapsed time per iteration: 
+      No 2-ints    :    0.00546098s
+      LL           :    0.02765676s
+
+
+                                   TOTAL ENERGY
+                                   ------------
+
+   Charge of molecule : 0
+
+   Electronic energy                        :    -133.65283887770988
+
+   Other contributions to the total energy
+   Nuclear repulsion energy                 :      25.92968333424700
+
+   Sum of all contributions to the energy
+   Total energy                             :    -107.72315554346288
+
+
+                                   Eigenvalues
+                                   -----------
+
+
+* Block   1 in E1g:  Omega =  1/2
+  * Closed shell, f = 1.0000
+ -15.4784350021385  ( 2)     -1.5655313422294  ( 2)     -0.5979846687402  ( 2)
+  * Virtual eigenvalues, f = 0.0000
+   0.2663058042062  ( 2)      0.9539627870752  ( 2)      1.2544304326990  ( 2)      1.3007269323931  ( 2)      6.1356231350524  ( 2)
+   6.5059191776069  ( 2)      8.3761744747877  ( 2)     30.0290105950733  ( 2)    144.6162299424441  ( 2)
+
+* Block   2 in E1g:  Omega =  3/2
+  * Virtual eigenvalues, f = 0.0000
+   0.2665434262340  ( 2)      1.3011409611415  ( 2)      6.1376290496029  ( 2)
+
+* Block   1 in E1u:  Omega =  1/2
+  * Closed shell, f = 1.0000
+ -15.4717131240215  ( 2)     -0.7134975799060  ( 2)     -0.6331055572598  ( 2)
+  * Virtual eigenvalues, f = 0.0000
+   0.8439713539693  ( 2)      1.0581170380742  ( 2)      1.4064444331398  ( 2)      2.0495833529236  ( 2)      5.8417355507112  ( 2)
+   5.8638118031452  ( 2)      8.6715070200833  ( 2)     30.3351528572970  ( 2)    144.9053585228463  ( 2)
+
+* Block   2 in E1u:  Omega =  3/2
+  * Closed shell, f = 1.0000
+  -0.6327385145180  ( 2)
+  * Virtual eigenvalues, f = 0.0000
+   1.0584140397995  ( 2)      5.8657954681136  ( 2)
+
+* Occupation in fermion symmetry E1g
+  * Inactive orbitals
+      1/2  1/2  1/2
+  * Virtual orbitals
+      1/2  3/2  1/2  1/2  1/2  3/2  1/2  3/2  1/2  1/2  1/2  1/2
+
+* Occupation in fermion symmetry E1u
+  * Inactive orbitals
+      1/2  1/2  1/2  3/2
+  * Virtual orbitals
+      1/2  1/2  3/2  1/2  1/2  1/2  1/2  3/2  1/2  1/2  1/2
+
+* Occupation of subblocks
+                       E1g:   1/2  3/2                                                                      
+  closed shells (f=1.0000):    3    0
+ virtual shells (f=0.0000):    9    3
+tot.num. of pos.erg shells:   12    3
+                       E1u:   1/2  3/2                                                                      
+  closed shells (f=1.0000):    3    1
+ virtual shells (f=0.0000):    9    2
+tot.num. of pos.erg shells:   12    3
+
+
+* HOMO - LUMO gap:
+
+    E(LUMO) :     0.26630580 au (symmetry E1g)
+  - E(HOMO) :    -0.59798467 au (symmetry E1g)
+  ------------------------------------------
+    gap     :     0.86429047 au
+
+
+
+    **************************************************************************
+    ****************************** Vector print ******************************
+    **************************************************************************
+
+
+
+   Coefficients from CHECKPOINT
+   ----------------------------
+
+
+
+                                Fermion ircop E1g
+                                -----------------
+
+
+* Electronic eigenvalue no.  1: -15.478435002138
+====================================================
+       1  L Ag N2 s      -0.1087029210  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s      -0.3634905354  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s      -0.3389337893  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       0.0207572927  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s      -0.0245565484  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.0045584497  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.0021662874  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.0008144258  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz     -0.0008183582  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000 -0.0000023354  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000  0.0000007495  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000 -0.0000003427  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0000023354
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0000007495
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0000003427
+
+* Electronic eigenvalue no.  2: -1.5655313422294
+====================================================
+       1  L Ag N2 s      -0.0259692332  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s      -0.1054286646  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s      -0.1376778786  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s      -0.0151072330  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s       0.3223231390  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.2322201327  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz     -0.0782129457  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz     -0.1990654732  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz     -0.0163752904  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000 -0.0000568866  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000 -0.0000532946  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000 -0.0000088838  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0000568866
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0000532946
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0000088838
+
+* Electronic eigenvalue no.  3: -0.5979846687402
+====================================================
+       1  L Ag N2 s      -0.0080045413  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s      -0.0289408386  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s      -0.1083146492  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       0.0810498556  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s      -0.0075089446  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.4193112596  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.1406130642  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.3375088385  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz      0.2014853205  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000  0.0001406270  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000  0.0002147783  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000  0.0001282107  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0001406270
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0002147783
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0001282107
+
+* Electronic eigenvalue no.  4:  0.2663058042062
+====================================================
+       1  L Ag N2 s       0.0000016785  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s       0.0000106018  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s      -0.0000480335  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       0.0000760911  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s      -0.0001275471  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.0003449331  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.0000097282  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.0001342193  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz      0.0003869729  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000 -0.0963830851  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000 -0.2056098978  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000 -0.5011847649  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0963830851
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.2056098978
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.5011847649
+
+* Electronic eigenvalue no.  5:  0.2665434262340
+====================================================
+       1  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000  0.0962792072  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000  0.2054798730  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000  0.5014568081  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0962792072
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.2054798730
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.5014568081
+
+* Electronic eigenvalue no.  6:  0.9539627870752
+====================================================
+       1  L Ag N2 s       0.0066099329  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s       0.0418437841  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s      -0.1881928278  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       0.3150225471  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s      -0.6991300750  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.2344247242  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.0580927797  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.5027169547  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz     -1.0463216451  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000  0.0000623367  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000  0.0001868211  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000 -0.0005019718  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0000623367
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0001868211
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0005019718
+
+* Electronic eigenvalue no.  7:  1.2544304326990
+====================================================
+       1  L Ag N2 s      -0.0215930827  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s      -0.1218049386  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s       0.3576640170  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s      -0.6733776577  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s       1.3832809953  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s      -1.0219771815  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.0667806419  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.3461935345  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz     -0.3515838278  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000  0.0004077279  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000  0.0021910081  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000 -0.0035341251  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0004077279
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0021910081
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0035341251
+
+* Electronic eigenvalue no.  8:  1.3007269323931
+====================================================
+       1  L Ag N2 s      -0.0000797442  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s      -0.0004508821  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s       0.0013303328  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s      -0.0025022297  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s       0.0050520893  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s      -0.0038062362  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.0002328432  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.0017764357  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz     -0.0018524325  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000 -0.1002910759  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000 -0.5810526061  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000  0.8902996693  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.1002910759
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.5810526061
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.8902996693
+
+* Electronic eigenvalue no.  9:  1.3011409611415
+====================================================
+       1  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000 -0.1002234553  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000 -0.5812449870  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000  0.8901955692  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.1002234553
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.5812449870
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.8901955692
+
+* Electronic eigenvalue no. 10:  6.1356231350524
+====================================================
+       1  L Ag N2 s      -0.0000288143  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s      -0.0000063647  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s      -0.0022766620  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       0.0028186369  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s      -0.0010959263  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.0006581741  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.0033923743  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz     -0.0031496919  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz      0.0016212689  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000  0.6178821237  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000 -0.6924156444  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000  0.4030235644  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.6178821237
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.6924156444
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.4030235644
+
+* Electronic eigenvalue no. 11:  6.1376290496029
+====================================================
+       1  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000  0.6179140795  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000 -0.6923011087  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000  0.4029336881  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.6179140795
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.6923011087
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.4029336881
+
+* Electronic eigenvalue no. 12:  6.5059191776069
+====================================================
+       1  L Ag N2 s      -0.0093822134  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s      -0.0029833709  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s      -0.7390040442  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       0.9112141405  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s      -0.3244962326  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.1805371022  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.8849618561  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz     -0.7947301488  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz      0.4034229394  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000 -0.0023918363  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000  0.0025813452  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000 -0.0014884767  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0023918363
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0025813452
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0014884767
+
+* Electronic eigenvalue no. 13:  8.3761744747877
+====================================================
+       1  L Ag N2 s      -0.0713510918  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s      -0.0890313335  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s      -5.0530119310  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       6.2195086227  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s      -1.5378927227  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.4810060628  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz     -0.1499218059  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.0753152814  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz     -0.0881792545  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000  0.0000674838  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000 -0.0000682740  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000  0.0000393684  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0000674838
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0000682740
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0000393684
+
+* Electronic eigenvalue no. 14:  30.029010595073
+====================================================
+       1  L Ag N2 s       0.0742976891  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s       1.4060477382  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s      -9.1081834400  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s       8.4709890448  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s      -0.9357275989  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s       0.2577118042  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz     -0.0316485474  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz      0.0063523450  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz     -0.0287438242  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000  0.0000020283  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000 -0.0000018547  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000  0.0000010732  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0000020283
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0000018547
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0000010732
+
+* Electronic eigenvalue no. 15:  144.61622994244
+====================================================
+       1  L Ag N2 s       1.0044013346  0.0000000000  0.0000000000  0.0000000000
+       2  L Ag N2 s      -1.5577339692  0.0000000000  0.0000000000  0.0000000000
+       3  L Ag N2 s       4.4244983404  0.0000000000  0.0000000000  0.0000000000
+       4  L Ag N2 s      -3.8219372858  0.0000000000  0.0000000000  0.0000000000
+       5  L Ag N2 s       0.3700448500  0.0000000000  0.0000000000  0.0000000000
+       6  L Ag N2 s      -0.1034125487  0.0000000000  0.0000000000  0.0000000000
+       7  L Ag N2 pz      0.0102453558  0.0000000000  0.0000000000  0.0000000000
+       8  L Ag N2 pz     -0.0003045376  0.0000000000  0.0000000000  0.0000000000
+       9  L Ag N2 pz      0.0103537835  0.0000000000  0.0000000000  0.0000000000
+      10  L B2gN2 px      0.0000000000  0.0000000000 -0.0000000217  0.0000000000
+      11  L B2gN2 px      0.0000000000  0.0000000000  0.0000000354  0.0000000000
+      12  L B2gN2 px      0.0000000000  0.0000000000 -0.0000000218  0.0000000000
+      13  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0000000217
+      14  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000  0.0000000354
+      15  L B3gN2 py      0.0000000000  0.0000000000  0.0000000000 -0.0000000218
+
+
+                                Fermion ircop E1u
+                                -----------------
+
+
+* Electronic eigenvalue no.  1: -15.471713124021
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0000025110
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0000003012
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0000001147
+       4  L B2uN2 py      0.0000000000  0.0000000000 -0.0000025110  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000  0.0000003012  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000 -0.0000001147  0.0000000000
+       7  L B1uN2 s       0.0000000000  0.1088325869  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000  0.3637866395  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000  0.3414501756  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000 -0.0233087200  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000  0.0271638896  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000 -0.0180412837  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000 -0.0021173601  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000 -0.0011236868  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000  0.0065053293  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  2: -0.7134975799060
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0002723706
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0006226804
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0004728030
+       4  L B2uN2 py      0.0000000000  0.0000000000  0.0002723706  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000  0.0006226804  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000  0.0004728030  0.0000000000
+       7  L B1uN2 s       0.0000000000  0.0224278576  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000  0.0903526515  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000  0.1512707634  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000 -0.0244481266  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000 -0.2444224696  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000 -0.5536453608  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000 -0.0705272132  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000 -0.1352290620  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000 -0.1304630813  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  3: -0.6331055572598
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0900904444
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.2235171103
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.1953451532
+       4  L B2uN2 py      0.0000000000  0.0000000000 -0.0900904444  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000 -0.2235171103  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000 -0.1953451532  0.0000000000
+       7  L B1uN2 s       0.0000000000  0.0000603615  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000  0.0002458612  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000  0.0003725939  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000 -0.0000150591  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000 -0.0007603382  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000 -0.0009264907  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000 -0.0000760527  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000 -0.0002538717  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000 -0.0007256743  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  4: -0.6327385145180
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0900038581
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.2234623460
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.1954393094
+       4  L B2uN2 py      0.0000000000  0.0000000000 -0.0900038581  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000 -0.2234623460  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000 -0.1954393094  0.0000000000
+       7  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  5:  0.8439713539693
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0000048091
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0000978183
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0001235591
+       4  L B2uN2 py      0.0000000000  0.0000000000 -0.0000048091  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000 -0.0000978183  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000  0.0001235591  0.0000000000
+       7  L B1uN2 s       0.0000000000 -0.0156012537  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000 -0.0619154041  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000 -0.1465964420  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000  0.0681413604  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000  0.0308510507  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000  4.1176415154  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000 -0.0352321629  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000  0.0285667499  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000 -2.7350824422  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  6:  1.0581170380742
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0772649612
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.5234474280
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.5219717445
+       4  L B2uN2 py      0.0000000000  0.0000000000 -0.0772649612  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000 -0.5234474280  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000  0.5219717445  0.0000000000
+       7  L B1uN2 s       0.0000000000  0.0000071496  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000  0.0000260050  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000  0.0001013077  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000 -0.0000708119  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000  0.0000419210  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000 -0.0013326184  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000  0.0002177841  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000  0.0005783430  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000  0.0003301393  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  7:  1.0584140397995
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0772005691
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.5235769669
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.5219586350
+       4  L B2uN2 py      0.0000000000  0.0000000000  0.0772005691  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000  0.5235769669  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000 -0.5219586350  0.0000000000
+       7  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  8:  1.4064444331398
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0000164064
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0004466502
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0003419473
+       4  L B2uN2 py      0.0000000000  0.0000000000 -0.0000164064  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000  0.0004466502  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000 -0.0003419473  0.0000000000
+       7  L B1uN2 s       0.0000000000 -0.0058983181  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000 -0.0406249246  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000  0.2081301132  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000 -0.3308193519  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000  0.7223842187  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000 -2.2230277870  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000  0.1476570279  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000  0.8987675553  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000  0.3532003171  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no.  9:  2.0495833529236
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0000648003
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0002381134
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0001293214
+       4  L B2uN2 py      0.0000000000  0.0000000000 -0.0000648003  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000  0.0002381134  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000 -0.0001293214  0.0000000000
+       7  L B1uN2 s       0.0000000000  0.0265963624  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000  0.1483884124  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000 -0.4241656225  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000  0.8336612939  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000 -1.9805288927  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000  4.9056439377  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000  0.1374225852  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000  0.6499461715  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000 -2.3612175790  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 10:  5.8417355507112
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0391950886
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0362157195
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0145237037
+       4  L B2uN2 py      0.0000000000  0.0000000000  0.0391950886  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000 -0.0362157195  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000  0.0145237037  0.0000000000
+       7  L B1uN2 s       0.0000000000  0.0025637567  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000  0.0259726782  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000 -0.2880272603  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000  0.4465760724  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000 -0.6324203693  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000  1.0620879942  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000 -0.8666140650  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000  1.3387998254  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000 -0.9027905750  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 11:  5.8638118031452
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.6065070955
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.5590461962
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.2240709705
+       4  L B2uN2 py      0.0000000000  0.0000000000  0.6065070955  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000 -0.5590461962  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000  0.2240709705  0.0000000000
+       7  L B1uN2 s       0.0000000000 -0.0001623373  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000 -0.0016603091  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000  0.0185846698  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000 -0.0287979602  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000  0.0406899238  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000 -0.0682095884  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000  0.0560709688  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000 -0.0863300004  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000  0.0580749339  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 12:  5.8657954681136
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.6077933289
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.5601193886
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.2244905363
+       4  L B2uN2 py      0.0000000000  0.0000000000  0.6077933289  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000 -0.5601193886  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000  0.2244905363  0.0000000000
+       7  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000  0.0000000000  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 13:  8.6715070200833
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0000031457
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0000005689
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0000002203
+       4  L B2uN2 py      0.0000000000  0.0000000000  0.0000031457  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000 -0.0000005689  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000  0.0000002203  0.0000000000
+       7  L B1uN2 s       0.0000000000 -0.0706016898  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000 -0.0667967700  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000 -5.5424634269  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000  6.9487336332  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000 -2.3719295293  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000  2.5114332073  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000 -0.0327553165  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000  0.3863882931  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000 -0.9909880941  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 14:  30.335152857297
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0000012033
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000  0.0000009441
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0000003225
+       4  L B2uN2 py      0.0000000000  0.0000000000  0.0000012033  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000 -0.0000009441  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000  0.0000003225  0.0000000000
+       7  L B1uN2 s       0.0000000000 -0.0748665717  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000 -1.4143130332  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000  9.3662435247  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000 -8.8279142169  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000  1.2914220937  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000 -1.1653502081  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000  0.0128875356  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000 -0.1600606426  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000  0.4425706343  0.0000000000  0.0000000000
+
+* Electronic eigenvalue no. 15:  144.90535852285
+====================================================
+       1  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0000000091
+       2  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0000000050
+       3  L B3uN2 px      0.0000000000  0.0000000000  0.0000000000 -0.0000000023
+       4  L B2uN2 py      0.0000000000  0.0000000000  0.0000000091  0.0000000000
+       5  L B2uN2 py      0.0000000000  0.0000000000  0.0000000050  0.0000000000
+       6  L B2uN2 py      0.0000000000  0.0000000000  0.0000000023  0.0000000000
+       7  L B1uN2 s       0.0000000000 -1.0053571583  0.0000000000  0.0000000000
+       8  L B1uN2 s       0.0000000000  1.5686739868  0.0000000000  0.0000000000
+       9  L B1uN2 s       0.0000000000 -4.5666682097  0.0000000000  0.0000000000
+      10  L B1uN2 s       0.0000000000  3.9999448650  0.0000000000  0.0000000000
+      11  L B1uN2 s       0.0000000000 -0.5161346910  0.0000000000  0.0000000000
+      12  L B1uN2 s       0.0000000000  0.4771435310  0.0000000000  0.0000000000
+      13  L B1uN2 pz      0.0000000000 -0.0058155378  0.0000000000  0.0000000000
+      14  L B1uN2 pz      0.0000000000  0.0647789390  0.0000000000  0.0000000000
+      15  L B1uN2 pz      0.0000000000 -0.1827816405  0.0000000000  0.0000000000
+
+
+    **************************************************************************
+    ********************** Mulliken population analysis **********************
+    **************************************************************************
+
+
+
+                                Fermion ircop E1g
+                                -----------------
+
+
+
+                                Fermion ircop E1g
+                                -----------------
+
+
+* Electronic eigenvalue no.   1: -15.478435002138       (Occupation : f = 1.0000)  m_j=  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L Ag N2 s   
+--------------------------------------
+ alpha    1.0000  |      1.0001
+ beta     0.0000  |      0.0000
+
+* Electronic eigenvalue no.   2: -1.5655313422294       (Occupation : f = 1.0000)  m_j=  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L Ag N2 s      L Ag N2 pz  
+-----------------------------------------------------
+ alpha    1.0000  |      0.7330         0.2670
+ beta     0.0000  |      0.0000         0.0000
+
+* Electronic eigenvalue no.   3: -0.5979846687402       (Occupation : f = 1.0000)  m_j=  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L Ag N2 s      L Ag N2 pz  
+-----------------------------------------------------
+ alpha    1.0000  |      0.3448         0.6552
+ beta     0.0000  |      0.0000         0.0000
+
+
+** Total gross population of fermion ircop E1g **
+
+Gross      Total    |    L Ag N2 s      L Ag N2 pz  
+-----------------------------------------------------
+ total     6.00000  |      4.15570        1.84430
+
+
+                                Fermion ircop E1u
+                                -----------------
+
+
+
+                                Fermion ircop E1u
+                                -----------------
+
+
+* Electronic eigenvalue no.   1: -15.471713124021       (Occupation : f = 1.0000)  m_j=  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L B1uN2 s      L B1uN2 pz  
+-----------------------------------------------------
+ alpha    1.0000  |      0.9986         0.0014
+ beta     0.0000  |      0.0000         0.0000
+
+* Electronic eigenvalue no.   2: -0.7134975799060       (Occupation : f = 1.0000)  m_j=  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L B1uN2 s      L B1uN2 pz  
+-----------------------------------------------------
+ alpha    1.0000  |      0.6919         0.3081
+ beta     0.0000  |      0.0000         0.0000
+
+* Electronic eigenvalue no.   3: -0.6331055572598       (Occupation : f = 1.0000)  m_j=  1/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L B3uN2 px     L B2uN2 py  
+-----------------------------------------------------
+ alpha    0.0000  |      0.0000         0.0000
+ beta     1.0000  |      0.5000         0.5000
+
+* Electronic eigenvalue no.   4: -0.6327385145180       (Occupation : f = 1.0000)  m_j= -3/2
+============================================================================================
+
+* Gross populations greater than 0.00010
+
+Gross     Total   |    L B3uN2 px     L B2uN2 py  
+-----------------------------------------------------
+ alpha    0.0000  |      0.0000         0.0000
+ beta     1.0000  |      0.5000         0.5000
+
+
+** Total gross population of fermion ircop E1u **
+
+Gross      Total    |    L B3uN2 px     L B2uN2 py     L B1uN2 s      L B1uN2 pz  
+-----------------------------------------------------------------------------------
+ total     8.00000  |      2.00000        2.00000        3.38108        0.61892
+
+
+*** Total gross population ***
+
+Gross      Total    |    L Ag N2 s      L Ag N2 pz     L B3uN2 px     L B2uN2 py     L B1uN2 s      L B1uN2 pz  
+-----------------------------------------------------------------------------------------------------------------
+ total    14.00000  |      4.15570        1.84430        2.00000        2.00000        3.38108        0.61892
+===========================================================================
+* PCMOUT: Coefficients read from CHECKPOINT 
+          and written to formatted DFPCMO
+===========================================================================
+
+
+    **************************************************************************
+    **************** Transformation to Molecular Spinor Basis ****************
+    **************************************************************************
+
+
+          Written by Luuk Visscher, Jon Laerdahl & Trond Saue
+          Odense, 1997
+
+
+
+
+     ************************************************************************
+     **************** Transformation of 2-electron integrals ****************
+     ************************************************************************
+
+
+ Transformation started at : Mon Apr 15 01:46:22 2024
+
+* REACMO: Coefficients read from CHECKPOINT  - Total energy: -107.723155543462596
+* Heading : Data read from the checkpoint file                                       
+
+* Orbital ranges for 4-index transformation:
+
+
+ * Fermion ircop E1g
+
+      Index 1   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+      Index 2   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+      Index 3   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+      Index 4   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+
+ * Fermion ircop E1u
+
+      Index 1   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+      Index 2   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+      Index 3   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+      Index 4   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+ (PAMTRA)  Orbitals read from CHECKPOINT
+
+* Core orbital ranges for 2-index transformation:
+
+
+ * Fermion ircop E1g
+
+      No orbitals for index 1
+
+
+ * Fermion ircop E1u
+
+      No orbitals for index 1
+
+
+    **************************************************************************
+    **************** Transformation to Molecular Spinor Basis ****************
+    **************************************************************************
+
+
+          Written by Luuk Visscher, Jon Laerdahl & Trond Saue
+          Odense, 1997
+
+
+
+
+      **********************************************************************
+      **************** Transformation of property integrals ****************
+      **********************************************************************
+
+
+ Transformation started at : Mon Apr 15 01:46:22 2024
+
+* REACMO: Coefficients read from CHECKPOINT  - Total energy: -107.723155543462596
+* Heading : Data read from the checkpoint file                                       
+
+
+ * Fermion ircop E1g
+
+      Index 1   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+      Index 2   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+
+ * Fermion ircop E1u
+
+      Index 1   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+      Index 2   15 orbitals
+          1    2    3    4    5    6    7    8    9   10   11   12
+         13   14   15
+
+
+    **************************************************************************
+    **************** Transformation to Molecular Spinor Basis ****************
+    **************************************************************************
+
+
+          Written by Luuk Visscher, Jon Laerdahl & Trond Saue
+          Odense, 1997
+
+
+
+
+       ********************************************************************
+       **************** Transformation of core Fock matrix ****************
+       ********************************************************************
+
+
+ Transformation started at : Mon Apr 15 01:46:22 2024
+
+* REACMO: Coefficients read from CHECKPOINT  - Total energy: -107.723155543462596
+* Heading : Data read from the checkpoint file                                       
+
+* REAFCK: Fock matrix read from file /home/noda/DIRAC_scratch_directory/noda/DIRAC_N2_N2_570962/D
+* Heading :N2                                                Mon Apr 15 01:46:21 2024
+
+
+ Core energy (includes nuclear repulsion) :             25.9296833342
+ - Electronic part :                                     0.0000000000
+   - One-electron terms :                                0.0000000000
+   - Two-electron terms :                                0.0000000000
+
+
+ MOLFDIR file MRCONEE is written
+
+ * Max no. of B shells in a task determined to be   1
+ - Integral class 2 : (SS|??)
+ - Integral class 1 : (LL|??)
+   - Starting shell A no.    2 after           0.00 seconds.
+   - Starting shell A no.    1 after           0.00 seconds.
+ Node    3 slept during first half transformation.
+ Node    6 slept during first half transformation.
+ Node    7 slept during first half transformation.
+ Node    2 slept during first half transformation.
+ Node    5 finished first half transformation           23868 HT integrals written ( 68.00%,      0.00 GB)
+ Node    4 finished first half transformation           82512 HT integrals written ( 84.89%,      0.00 GB)
+ Node    1 finished first half transformation           60750 HT integrals written ( 78.95%,      0.00 GB)
+
+
+   Integrals written :
+
+
+   Integrals written :
+
+
+   Integrals written :
+
+
+   Integrals written :
+
+
+   Integrals written :
+
+
+   Integrals written :
+
+
+   Integrals written :
+
+
+   Integrals written :
+ >>> CPU time used in 2HT_all is   0.32 seconds
+ >>> CPU time used in 2HT_all is   0.35 seconds
+ >>> CPU time used in 2HT_all is   0.40 seconds
+ >>> CPU time used in 2HT_all is   0.42 seconds
+ - Binary  file MDCINT was written.
+ >>> CPU time used in 2HT_all is   0.42 seconds
+ >>> CPU time used in 2HT_all is   0.42 seconds
+ >>> CPU time used in 2HT_all is   0.42 seconds
+ >>> CPU time used in 2HT_all is   0.42 seconds
+* Screening statistics:
+   (LL|LL)ints :   0.00%
+   Total       :   0.00%
+
+------ Timing report (in CPU seconds) of module  integral transformation      
+
+
+
+                                    Master   --------- Slaves ------------
+
+ Timer                              Master   Minimum   Maximum     Average
+
+  First halftransformation             1.4       1.3       1.3       1.3
+  Slave requesting task from ma        0.0       0.0       0.0       0.0
+  Master and slave negotiating         0.0       0.0       0.0       0.0
+  Second halftransformation            0.4       0.3       0.4       0.4
+
+------ End of timing report ------
+
+
+
+ Total wall time used in PAMTRA :   00:00:02
+ Total CPU  time used in PAMTRA (master only) :   00:00:02
+
+ Transformation ended at : Mon Apr 15 01:46:23 2024
+
+
+---< Process     1 of     8----<
+
+
+
+ Relativistic Coupled Cluster program RELCCSD
+
+ Written by :
+    Lucas Visscher
+
+    NASA Ames Research Center    (1994)
+    Rijks Universiteit Groningen (1995)
+    Odense Universitet           (1996-1997)
+    VU University Amsterdam      (1998-present)
+
+
+ This module is documented in
+  - Initial implementation : L. Visscher, T.J. Lee and K.G. Dyall, J. Chem. Phys. 105 (1996) 8769.
+  - Fock Space (FSCC)      : L. Visscher, E. Eliav and U. Kaldor, J. Chem. Phys. 115 (2002) 9720.
+  - Parallelization        : M. Pernpointner and L. Visscher, J. Comp. Chem. 24 (2003) 754.
+  - Intermediate Hamilt. FS: E. Eliav, M. J. Vilkas, Y. Ishikawa, and U. Kaldor, J. Chem. Phys. 122 (2005) 224113.
+  - MP2 expectation values : J.N.P. van Stralen, L. Visscher, C.V. Larsen and H.J.Aa. Jensen," Chem. Phys. 311 (2005) 81.
+  - CC  expectation values : A. Shee, L. Visscher, and T. Saue, J. Chem. Phys. 145 (2016) 184107.
+  - EOM-IP/EA/EE energies  : A. Shee, T. Saue, L. Visscher, and A.S.P. Gomes, J. Chem. Phys. 149 (2018) 174113.
+  - Core spectra (CVS-EOM) : L. Halbert, M. L. Vidal, A. Shee, S. Coriani, and A.S.P. Gomes, arXiv:2011.08549
+
+
+ Today is :    15 Apr 24
+ The time is :  01:46:23
+
+ Initializing word-addressable I/O : the FORTRAN-interface is used with    16 KB records
+===========================================================================
+ **RELCC: Set-up for Coupled Cluster calculations
+===========================================================================
+ * General print level   :   0
+
+ Total memory available :       16384.00 MB   16.000 GB
+ 
+ INFO: No old restart file(s) found!
+ 
+
+ Configuration in highest pointgroup
+
+                                          Eg   Eg   Eu   Eu
+ Spinor class : occupied                   3    3    4    4
+ Spinor class : virtual                   12   12   11   11
+
+ Configuration in abelian subgroup
+
+                                          1g  -1g   3g  -3g   1u  -1u   3u  -3u
+ Spinor class : occupied                   3    3    0    0    3    3    1    1
+ Spinor class : virtual                    9    9    3    3    9    9    2    2
+
+
+ Number of electrons :                    14
+ Total charge of the system :              0
+ Number of virtual spinors :              46
+ Complex arithmetic mode :                 F
+ Do integral sorting     :                 T
+ Do energy calculation   :                 T
+ Do gradient calculation :                 F
+ Do response calculation :                 F
+ Debug information       :                 F
+ Timing information      :                 F
+ Print level          :                    0
+ Memory limit (MWord) :                      2048
+ Interface used       :                DIRAC6    
+
+
+ Leave after calculating the total memory demand :          F
+ Memory for reading and sorting integrals :               726050 8-byte words
+ Core used for calculating amplitudes :                   235861 8-byte words
+ Core used for in core evaluation of triples :            135465 8-byte words
+ Memory used for active modules :                         726050 8-byte words
+
+ Predicted RelCC memory demand:            5.54 MB
+ Predicted RelCC memory demand:           0.005 GB
+
+ Expanding and sorting integrals to unique types :
+ Type OOOO :            1171 integrals
+ Type VOOO :            7744 integrals
+ Type VVOO :           12127 integrals
+ Type VOVO :           52206 integrals
+ Type VOVV :           81716 integrals
+ Type VVVV :          128235 integrals
+ 
+ Start sorting of integral classes at  15 Apr 24 01:46:23
+ 
+ 
+ Sorting of first 4 classes done at  15 Apr 24 01:46:24
+
+ Need      1 passes to sort VOVV integrals
+ 
+ Pass     1 ended at  15 Apr 24 01:46:24
+ 
+ VOVV sorting done at  15 Apr 24 01:46:24
+
+ Need      1 passes to sort VVVV integrals
+ 
+ Pass     1 ended at  15 Apr 24 01:46:24
+ 
+ VVVV sorting done at  15 Apr 24 01:46:24
+
+ Reading Coulomb integrals :
+ File date :      15 Apr 24
+ File time :       01:46:24
+ # of integrals              767036
+
+ Finished sorting of integrals
+
+
+ Single determinant electronic energy :     -133.652838877709826
+
+
+ Checking the orbital energies, the program computes the diagonal elements of the
+ reconstructed Fock matrix. Differences with the reference orbital energies
+ are given if above a treshold or if iprnt > 1
+
+ Spinor   Abelian Rep.         Energy   Recalc. Energy
+
+ The diagonal elements of the recomputed Fock matrix (right column) are used in perturbation expressions.
+
+ Use the perturbative values (MP2, CCSD[T]/(T)/-T) with care, especially
+ in  open shell calculations because the orbitals need not always be
+ semi-canonical as was assumed in the derivation of the expressions.
+ The missing terms may be important !
+
+
+ Nuclear repulsion + core energy :            25.929683334246999
+ Zero order electronic energy :              -70.186012074958313
+ First order electronic energy :             -63.466826802751520
+ Electronic energy :                        -133.652838877709826
+ SCF energy :                               -107.723155543462823
+
+
+ Energy calculations
+ MP2 module active :                       T
+ CCSD module active :                      T
+ CCSD(T) module active :                   T
+
+
+  MP2 results
+
+ SCF energy :                               -107.723155543462823
+ MP2 correlation energy :                     -0.252811770693328
+ Total MP2 energy :                         -107.975967314156151
+ T1 diagnostic :                               0.000000017978630
+
+
+ CCSD options :
+ Maximum number of iterations :           30
+ Maximum size of DIIS space :              8
+ Convergence criterium :             0.1E-11
+
+
+  CCSD results
+
+ SCF energy :                               -107.723155543462823
+ CCSD correlation energy :                    -0.252668365231671
+ Total CCSD energy :                        -107.975823908694494
+ T1 diagnostic :                               0.010095890818183
+ Convergence :                                 0.000000000000706
+ Number or iterations used :                                  16
+
+
+  Perturbative treatment of triple excitations
+
+ SCF energy :                               -107.723155543462823
+ CCSD correlation energy :                    -0.252668365231671
+ 4th order triples correction :               -0.007857214246955
+ 5th order triples (T) correction :            0.000448317384889
+ 5th order triples -T  correction :            0.000695099281724
+ Total CCSD+T  energy :                     -107.983681122941448
+ Total CCSD(T) energy :                     -107.983232805556554
+ Total CCSD-T  energy :                     -107.982986023659720
+
+
+--------------------------------------------------------------------------------
+
+
+ Today is :    15 Apr 24
+ The time is :  01:46:24
+
+ Status of the calculations
+ Integral sort # 1 :                   Completed, restartable        
+ Integral sort # 2 :                   Completed, restartable        
+ Fock matrix build :                   Completed, restartable        
+ MP2 energy calculation :              Completed, restartable        
+ CCSD energy calculation :             Completed, restartable        
+ CCSD(T) energy calculation :          Completed, restartable        
+ CCSD(T) energy calculation :          Completed, restartable        
+
+ Overview of calculated energies
+@ SCF energy :                              -107.723155543462823
+@ MP2 correlation energy :                    -0.252811770693328
+@ CCSD correlation energy :                   -0.252668365231671
+@ 4th order triples correction :              -0.007857214246955
+@ 5th order triples (T) correction :           0.000448317384889
+@ 5th order triples -T  correction :           0.000695099281724
+@ Total MP2 energy :                        -107.975967314156151
+@ Total CCSD energy :                       -107.975823908694494
+@ Total CCSD+T  energy :                    -107.983681122941448
+@ Total CCSD(T) energy :                    -107.983232805556554
+@ Total CCSD-T  energy :                    -107.982986023659720
+
+
+--------------------------------------------------------------------------------
+
+------ Timing report (in CPU seconds) of module  RELCCSD                      
+
+
+
+                                    Master   --------- Slaves ------------
+
+ Timer                              Master   Minimum   Maximum     Average
+
+ Sorting of integrals                  0.3       0.3       0.4       0.3
+ CCSD equations                        0.1       0.1       0.1       0.1
+ - T1 equations                        0.0       0.0       0.0       0.0
+ --- T1EQNS T*[HOV - F]*T              0.0       0.0       0.0       0.0
+ --- T1EQNS HOV*T2(A,C,I,K             0.0       0.0       0.0       0.0
+ --- T1EQNS   HV*T / T*HO              0.0       0.0       0.0       0.0
+ --- T1EQNS VOOO*TAU                   0.0       0.0       0.0       0.0
+ --- T1EQNS VOVV contribution          0.0       0.0       0.0       0.0
+ --- T1EQNS VOVO * T(C,K)              0.0       0.0       0.0       0.0
+ -- GOINTM                             0.0       0.0       0.0       0.0
+ -- GVINTM                             0.0       0.0       0.0       0.0
+ -- AINTM                              0.0       0.0       0.0       0.0
+ -- HINTM                              0.0       0.0       0.0       0.0
+ --- HINTM: VOVV*T                     0.0       0.0       0.0       0.0
+ --- HINTM: VVOO contribution          0.0       0.0       0.0       0.0
+ -- combining HINTM via MPI_ALL        0.0       0.0       0.0       0.0
+ -- T2 EQNS                            0.0       0.0       0.0       0.0
+ --- T2EQNS: TAU*AINTM contract        0.0       0.0       0.0       0.0
+ --- T2EQNS: VOVV*T1                   0.0       0.0       0.0       0.0
+ --- T2EQNS: HINTM*T2                  0.0       0.0       0.0       0.0
+ -- BINTM                              0.0       0.0       0.0       0.0
+ - adding partial T1/T2 amplitu        0.0       0.0       0.0       0.0
+ - DIIS extrapolation                  0.0       0.0       0.0       0.0
+ - synchronizing T1 & T2 amplit        0.0       0.0       0.0       0.0
+ CCSD(T) evaluation                    0.1       0.1       0.2       0.1
+ -- T3CORR: Integral resorting         0.0       0.0       0.0       0.0
+ -- T3CORR: VOVV contraction           0.0       0.0       0.0       0.0
+ -- T3CORR: addition of partial        0.1       0.1       0.1       0.1
+ -- T3CORR: energy calculation         0.0       0.0       0.0       0.0
+
+------ End of timing report ------
+
+
+
+ Timing of main modules :         Wallclock (s)       CPU on master (s)
+ Before CC driver :          ************                     2.81
+ Initialization :                    0.13                     0.13
+ Integral sorting :                  0.35                     0.35
+ Energy calculation :                0.33                     0.33
+ First order properties :            0.00                     0.00
+ Second order properties :           0.00                     0.00
+ Fock space energies :               0.00                     0.00
+ EOMCC energies :                    0.00                     0.00
+ Untimed parts :                     0.00                     0.00
+ Total time in CC driver :             1.                     0.81
+
+ Statistics for the word-addressable I/O
+ Number of write calls                                1658.
+ Number of read calls                                 1670.
+ Megabytes written                                    2.665
+ Megabytes read                                      31.659
+ Seconds spent in reads                               0.019
+ Seconds spent in writes                              0.019
+ average I/O speed for write (Mb/s)                 140.290
+ average I/O speed for read  (Mb/s)                1652.310
+
+
+ CPU time (seconds) used in RELCCSD:                     0.8078
+ CPU time (seconds) used before RELCCSD:                 2.8067
+ CPU time (seconds) used in total sofar:                 3.6145
+
+  --- Normal end of RELCCSD Run ---
+
+
+################################################################################
+
+
+       *******************************************************************
+       ************************* Property module *************************
+       *******************************************************************
+
+
+
+   This is output from the Dirac property module:
+
+   * HF & DFT first order properties
+      Trond Saue
+
+   * First-order ESR properties
+      Hans Joergen Aa. Jensen et al.
+
+   * MP2 first order properties:
+      J. N. P. van Stralen, L. Visscher, C. V. Larsen and H. J. Aa Jensen, Chem. Phys. 311 (2005) 81.
+
+   * KR-RPA second-order properties
+      Hans Joergen Aa. Jensen and Trond Saue
+
+   * KR-QR third order properties
+      Patrick Norman and Hans Joergen Aa. Jensen
+
+   * Oscillator strengths beyond the electric dipole approximation
+      N.H. List, T.R.L Melin, M. van Horn, T. Saue, J. Chem. Phys. 152 (2020) 184110
+
+   * Molecular gradient
+      Joern Thyssen
+
+   * Additional contributions from:
+      Thomas Enevoldsen, Miroslav Ilias (London orbitals)
+
+   * First-order exp. val. contribution from:
+      Chima Chibueze (KU DHF and KU CCSD)
+
+
+
+
+             *******************************************************
+             ********** Properties for DHF  wave function **********
+             *******************************************************
+
+
+
+    **************************************************************************
+    *************************** Expectation values ***************************
+    **************************************************************************
+
+    Rho at nuc N2 01 :     250.5515011778 a.u.      s0 = F   t0 = F
+    Rho at nuc N2 02 :     0.00000000E+00 a.u.      s0 = T   t0 = F
+    ---------------------------------------------------------------------------
+    s0 = T : Expectation value zero by point group symmetry.
+    t0 = T : Expectation value zero by time reversal symmetry.
+----------------------------------------------------------------------------
+
+ * Closing HDF5 checkpoint file 
+    - Checkpoint file contains all required data, can be used for restarts
+    - Checkpoint file closed
+
+*****************************************************
+********** E N D   of   D I R A C  output  **********
+*****************************************************
+
+
+ 
+     Date and time (Linux)  : Mon Apr 15 01:46:26 2024
+     Host name              : DESKTOP-1C7AGIU                         
+
+>>>> Node 0, utime: 4, stime: 0, minflt: 6557, majflt: 38, nvcsw: 267, nivcsw: 19147, maxrss: 158360
+>>>> Total WALL time used in DIRAC: 5s
+  
+  Dynamical Memory Usage Summary for Master
+  
+  Mean allocation size (Mb) :        26.11
+  
+  Largest                    10  allocations
+  
+      488.28 Mb at subroutine pamprp_1_+0xb2                             for WORK in PAMPRP_1                          
+      488.28 Mb at subroutine pamtra_+0x15f                              for WORK in PAMTRA                            
+      488.28 Mb at subroutine pamana_+0x8b                               for WORK in PAMANA                            
+      488.28 Mb at subroutine psiscf_+0xaf                               for WORK in PSISCF                            
+      488.28 Mb at subroutine pamset_+0x277                              for WORK in PAMSET - 2                        
+      488.28 Mb at subroutine gmotra_+0x47b3                             for WORK in GMOTRA - part 2                   
+      488.28 Mb at subroutine gmotra_+0x53ba                             for WORK in GMOTRA                            
+      488.28 Mb at subroutine pamset_+0x7b                               for WORK in PAMSET - 1                        
+      488.28 Mb at subroutine MAIN__+0xd69                               for test allocation of work array in DIRAC mai
+        3.08 Mb at subroutine ccseti_+0x438                              for ibuf                                      
+  
+  Peak memory usage:       488.29 MB
+  Peak memory usage:        0.477 GB
+       reached at subroutine : define_sort_+0x1fe                        
+              for variable   : node_for_buffer                           
+  
+ MEMGET high-water mark:    0.00 MB
+
+*****************************************************
+DIRAC pam run in /home/noda/test/dirac/mdcint/N2/scheme6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["sum_dirac_dfcoef>=4.4.0", "PySide6", "qtpy"]
+dependencies = ["sum_dirac_dfcoef>=5.0.0", "PySide6", "qtpy"]
 
 [project.optional-dependencies]
 dev = ["coverage[toml]>=6.5", "pytest", "black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]

--- a/src/dcaspt2_input_generator/components/data.py
+++ b/src/dcaspt2_input_generator/components/data.py
@@ -46,7 +46,8 @@ class SpinorNumInfo(Dict[str, SpinorNumber]):
 class HeaderInfo:
     spinor_num_info: SpinorNumInfo = None
     moltra_info: MoltraInfo = None
-    point_group: Union[str, None] = None
+    point_group: str = ""
+    moltra_scheme: Union[int, None] = None
     electron_number: int = 0
 
     def __post_init__(self):

--- a/src/dcaspt2_input_generator/components/main_window.py
+++ b/src/dcaspt2_input_generator/components/main_window.py
@@ -94,7 +94,6 @@ class MainWindow(QMainWindow):
                 cur_nelec += min(rem_electrons, 2)
             return cur_nelec
 
-        output = ""
         inact = 0
         act = 0
         sec = 0
@@ -140,7 +139,7 @@ class MainWindow(QMainWindow):
             rem_electrons -= 2
         nroot = max(10, self.table_summary.user_input.selectroot_number.get_value())
 
-        output += f"ninact\n{inact}\n"
+        output = f"ninact\n{inact}\n"
         output += f"nact\n{act}\n"
         output += f"nelec\n{elec}\n"
         output += f"nsec\n{sec}\n"
@@ -148,6 +147,8 @@ class MainWindow(QMainWindow):
         output += f"selectroot\n{self.table_summary.user_input.selectroot_number.get_value()}\n"
         output += f"totsym\n{self.table_summary.user_input.totsym_number.get_value()}\n"
         output += f"diracver\n{self.table_summary.user_input.dirac_ver_number.get_value()}\n"
+        if table_data.header_info.moltra_scheme is not None:
+            output += f"scheme\n{table_data.header_info.moltra_scheme}\n"  # Explicitly set MOLTRA scheme.
 
         if not is_cas:
             ras1_str = create_ras_str(sorted(ras1_list))

--- a/src/dcaspt2_input_generator/components/table_widget.py
+++ b/src/dcaspt2_input_generator/components/table_widget.py
@@ -203,54 +203,56 @@ class TableWidget(QTableWidget):
                 msg = "The output file is not correct, IndexError"
                 raise IndexError(msg) from e
 
+        def read_header(rows: List[List[str]]):
+            try:
+                for idx, row in enumerate(rows):
+                    if len(row) <= 1:  # Empty line, end of header
+                        break
+                    elif idx == 0:
+                        # 1st line: Read key-value info
+                        # (e.g.) electron_num 18 point_group D2h moltra_scheme default
+                        if len(row) % 2 != 0:
+                            msg = f"1st header line must be even elements because this line is for key-value info.\
+len(1st header)={len(row)}"
+                            raise IndexError(msg)
+
+                        for key_idx in range(0, len(row), 2):  # loop only key
+                            value_idx = key_idx + 1
+                            key = row[key_idx]
+                            if key == "electron_num":
+                                table_data.header_info.electron_number = int(row[value_idx])
+                            elif key == "point_group":
+                                table_data.header_info.point_group = row[value_idx]
+                            elif key == "moltra_scheme":
+                                value = row[value_idx]
+                                if value == "default":
+                                    table_data.header_info.moltra_scheme = None
+                                else:
+                                    table_data.header_info.moltra_scheme = int(value)
+                    elif idx == 1:
+                        # 2nd line: MOLTRA range
+                        # (e.g.) E1g 16..85 E1u 11..91
+                        self.read_moltra_info(row)
+                    elif idx == 2:
+                        # 3rd line: Eigenvalue info
+                        # (e.g.) E1g closed 6 open 0 virtual 30 E1u closed 10 open 0 virtual 40
+                        # => table_data.header_info.spinor_num_info = {"E1g": SpinorNumber(6, 0, 30, 36),
+                        #                                              "E1u": SpinorNumber(10, 0, 40, 50)}
+                        self.read_spinor_num_info(row)
+                    else:
+                        # Skip unknown header info line
+                        continue
+            except ValueError as e:
+                msg = "The output file is not correct, ValueError"
+                raise ValueError(msg) from e
+            except IndexError as e:
+                msg = "The output file is not correct, IndexError"
+                raise IndexError(msg) from e
+
         table_data.reset()
         rows = [line.split() for line in open(file_path).readlines()]
-        try:
-            for idx, row in enumerate(rows):
-                if len(row) <= 1:  # Empty line, end of header
-                    break
-                elif idx == 0:
-                    # 1st line: Read key-value info
-                    # (e.g.) electron_num 18 point_group D2h moltra_scheme default
-                    if len(row) % 2 != 0:
-                        msg = f"1st header line must be even elements because this line is for key-value info.\
-len(1st header)={len(row)}"
-                        raise IndexError(msg)
-
-                    for key_idx in range(0, len(row), 2):  # loop only key
-                        value_idx = key_idx + 1
-                        key = row[key_idx]
-                        if key == "electron_num":
-                            table_data.header_info.electron_number = int(row[value_idx])
-                        elif key == "point_group":
-                            table_data.header_info.point_group = row[value_idx]
-                        elif key == "moltra_scheme":
-                            value = row[value_idx]
-                            if value == "default":
-                                table_data.header_info.moltra_scheme = None
-                            else:
-                                table_data.header_info.moltra_scheme = int(value)
-                elif idx == 1:
-                    # 2nd line: MOLTRA range
-                    # (e.g.) E1g 16..85 E1u 11..91
-                    self.read_moltra_info(row)
-                elif idx == 2:
-                    # 3rd line: Eigenvalue info
-                    # (e.g.) E1g closed 6 open 0 virtual 30 E1u closed 10 open 0 virtual 40
-                    # => table_data.header_info.spinor_num_info = {"E1g": SpinorNumber(6, 0, 30, 36),
-                    #                                              "E1u": SpinorNumber(10, 0, 40, 50)}
-                    self.read_spinor_num_info(row)
-                else:
-                    # Skip unknown header info line
-                    continue
-        except ValueError as e:
-            msg = "The output file is not correct, ValueError"
-            raise ValueError(msg) from e
-        except IndexError as e:
-            msg = "The output file is not correct, IndexError"
-            raise IndexError(msg) from e
-
         # output is space separated file
+        read_header(rows)
         set_table_data(rows)
         self.create_table()
         self.set_column_header_items()

--- a/src/dcaspt2_input_generator/controller/widget_controller.py
+++ b/src/dcaspt2_input_generator/controller/widget_controller.py
@@ -57,8 +57,7 @@ class WidgetController:
             rem_electrons -= 2
 
         # Create standard IVO input
-        output = ""
-        output += "ninact\n0\n"
+        output = "ninact\n0\n"
         output += f"nact\n{act}\n"
         output += f"nsec\n{sec}\n"
         output += f"nelec\n{act}\n"
@@ -70,6 +69,8 @@ class WidgetController:
             output += "" if sum(nvcut.values()) == 0 else f"nvcut\n{nvcut['E1']}\n"
         output += f"totsym\n{self.table_summary.user_input.totsym_number.get_value()}\n"
         output += f"diracver\n{self.table_summary.user_input.dirac_ver_number.get_value()}\n"
+        if table_data.header_info.moltra_scheme is not None:
+            output += f"scheme\n{table_data.header_info.moltra_scheme}\n"  # Explicitly set MOLTRA scheme.
         output += "end\n"
 
         # Save standard IVO input (replace active.ivo.inp)


### PR DESCRIPTION
- [sum_dirac_dfcoef v5.0.0](https://github.com/RQC-HU/sum_dirac_dfcoef/releases/tag/v5.0.0)がbreaking changeを含むので、v5.0.0以前は対応バージョンから外した
  - https://github.com/RQC-HU/sum_dirac_dfcoef/pull/109#issue-2242269371 にあるようにアウトプットのヘッダ情報に関するルールを決めたので、今後は後方互換性が保ちやすくなるものと思われる
- https://github.com/RQC-HU/sum_dirac_dfcoef/pull/109 を適用したsum_dirac_dfcoef v5.0.0に対応
- [\*\*MOLTRA > .SCHEMEを明示的に設定した例](https://github.com/RQC-HU/dcaspt2_input_generator/blob/e2d5e025498130dd03f50927d140dfb44d71d479/data/dirac23_scheme6_N2.out)を読み込んでactive.inpを出力させると以下のようにscheme 6が自動的に挿入される。
  - 明示的に指定していない場合はschemeオプションを設定しないようになる

active.inp
```
$ cat active.inp 
ninact
10
nact
8
nelec
4
nsec
42
nroot
10
selectroot
1
totsym
3
diracver
23
scheme
6
end
```

![image](https://github.com/RQC-HU/dcaspt2_input_generator/assets/103017367/0787f1ec-122b-4e12-9dde-a6766c0d68be)