### PR TITLE
fix: Temporarily limit PySide6 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["sum_dirac_dfcoef>=5.0.0", "PySide6", "qtpy"]
+dependencies = ["sum_dirac_dfcoef>=5.0.0", "PySide6<=6.6.3.1", "qtpy"]
 
 [project.optional-dependencies]
 dev = ["coverage[toml]>=6.5", "pytest", "black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]


### PR DESCRIPTION
- Restrict PySide 6 version up to 6.6.3.1 because the following error if this program uses PySide 6.7.0 and qtpy 2.4.1.
```PowerShell
PS C:\Users\none> dcaspt2_input_generator.exe
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\Scripts\dcaspt2_input_generator.exe\__main__.py", line 7, in <module>
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\dcaspt2_input_generator.py", line 35, in main
    app = MainApp()
          ^^^^^^^^^
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\dcaspt2_input_generator.py", line 14, in __init__
    self.init_gui()
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\dcaspt2_input_generator.py", line 19, in init_gui
    self.window = MainWindow(parent=None)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\components\main_window.py", line 30, in __init__
    self.init_UI()
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\components\main_window.py", line 46, in init_UI
    self.menu_bar = MenuBar()
                    ^^^^^^^^^
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\components\menu_bar.py", line 40, in __init__
    self.init_UI()
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\components\menu_bar.py", line 55, in init_UI
    self.color_settings_action = ColorSettingsDialogAction()
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\components\color_settings.py", line 46, in __init__
    self.init_UI()
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\components\color_settings.py", line 49, in init_UI
    self.color_settings_dialog = ColorSettingsDialog()
                                 ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\components\color_settings.py", line 12, in __init__
    self.init_UI()
  File "C:\Users\none\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\dcaspt2_input_generator\components\color_settings.py", line 28, in init_UI
    layout.addWidget(button)
TypeError: 'PySide6.QtWidgets.QBoxLayout.addWidget' called with wrong argument types:
  PySide6.QtWidgets.QBoxLayout.addWidget(QRadioButton)
Supported signatures:
  PySide6.QtWidgets.QBoxLayout.addWidget(PySide6.QtWidgets.QWidget, int = 0, PySide6.QtCore.Qt.AlignmentFlag = Default(Qt.Alignment))
```