### PR TITLE
Fix missing key

### DIFF
--- a/src/dcaspt2_input_generator/components/table_summary.py
+++ b/src/dcaspt2_input_generator/components/table_summary.py
@@ -77,7 +77,7 @@ class UserInput(QGridLayout):
         super().__init__()
         # 数値を入力するためのラベル
         self.totsym_label = QLabel("total symmetry number")
-        self.totsym_number = TotsymNumberInput(self.changed, default_num=settings.input.totsym)
+        self.totsym_number = TotsymNumberInput(self.changed, default_num=settings.input.total_symmetry)
         self.diracver_label = QLabel("DIRAC major version (if 21.1, type 21)")
         self.dirac_ver_number = NaturalNumberInput(bottom_num=12, default_num=settings.input.dirac_ver)
         self.ras1_max_hole_label = QLabel("ras1 max hole")

--- a/src/dcaspt2_input_generator/utils/settings.py
+++ b/src/dcaspt2_input_generator/utils/settings.py
@@ -20,7 +20,7 @@ class SettingsDict(Dict[str, Union[str, int]]):
 
 
 class UserInput:
-    totsym: int
+    total_symmetry: int
     ras1_max_hole: int
     ras3_max_electron: int
     dirac_ver: int
@@ -29,13 +29,14 @@ class UserInput:
     def __init__(self, json_dict: SettingsDict, default_settings: SettingsDict) -> None:
         # If the settings.json file exists, read the settings from the file
         self.json_dict = json_dict
-        keys = ["totsym", "ras1_max_hole", "ras3_max_electron", "dirac_ver"]
+        keys = ["total_symmetry", "ras1_max_hole", "ras3_max_electron", "dirac_ver"]
         for key in keys:
             if key in self.json_dict:
                 setattr(self, key, int(self.json_dict[key]))
             elif key in default_settings:
                 setattr(self, key, int(default_settings[key]))
             else:
+                print(f"skip key {key}")
                 pass # key is not in settings file nor default settings, skip it
 
 
@@ -73,7 +74,7 @@ class Settings:
         # Application Default Settings
         self.default_settings = SettingsDict(
             {
-                "total symmetry": 1,
+                "total_symmetry": 1,
                 "ras1_max_hole": 0,
                 "ras3_max_electron": 0,
                 "dirac_ver": 23,


### PR DESCRIPTION
- rename totsym to total_symmetry

- before
  ```
  noda@DESKTOP-1C7AGIU /tmp/dcaspt2_input_generator ((4472e1b...)) $ .venv/bin/dcaspt2_input_generator
  Failed to create wl_display (No such file or directory)
  qt.qpa.plugin: Could not load the Qt platform plugin "wayland" in "" even though it was found.
  Traceback (most recent call last):
    File "/tmp/dcaspt2_input_generator/.venv/bin/dcaspt2_input_generator", line 10, in <module>
      sys.exit(main())
               ~~~~^^
    File "/tmp/dcaspt2_input_generator/src/dcaspt2_input_generator/dcaspt2_input_generator.py", line 35, in main
      app = MainApp()
    File "/tmp/dcaspt2_input_generator/src/dcaspt2_input_generator/dcaspt2_input_generator.py", line 14, in __init__
      self.init_gui()
      ~~~~~~~~~~~~~^^
    File "/tmp/dcaspt2_input_generator/src/dcaspt2_input_generator/dcaspt2_input_generator.py", line 17, in init_gui
      from dcaspt2_input_generator.components.main_window import MainWindow
    File "/tmp/dcaspt2_input_generator/src/dcaspt2_input_generator/components/main_window.py", line 10, in <module>
      from dcaspt2_input_generator.components.menu_bar import MenuBar
    File "/tmp/dcaspt2_input_generator/src/dcaspt2_input_generator/components/menu_bar.py", line 1, in <module>
      from dcaspt2_input_generator.components.color_settings import ColorSettingsDialogAction
    File "/tmp/dcaspt2_input_generator/src/dcaspt2_input_generator/components/color_settings.py", line 1, in <module>
      from dcaspt2_input_generator.utils.settings import settings
    File "/tmp/dcaspt2_input_generator/src/dcaspt2_input_generator/utils/settings.py", line 97, in <module>
      settings = Settings()
    File "/tmp/dcaspt2_input_generator/src/dcaspt2_input_generator/utils/settings.py", line 88, in __init__
      self.input = UserInput(self.json_dict, self.default_settings)
                   ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/dcaspt2_input_generator/src/dcaspt2_input_generator/utils/settings.py", line 37, in __init__
      setattr(self, key, int(default_settings[key]))
                             ~~~~~~~~~~~~~~~~^^^^^
  KeyError: 'totsym'
  ```
- after
![image](https://github.com/user-attachments/assets/dd8179d7-ba54-45c4-a4a7-5e2691e6d088)
