### PR TITLE
table_summary.py: use total_symmetry key instead of totsym in get_input_values

### DIFF
--- a/src/dcaspt2_input_generator/components/table_summary.py
+++ b/src/dcaspt2_input_generator/components/table_summary.py
@@ -96,7 +96,7 @@ class UserInput(QGridLayout):
 
     def get_input_values(self):
         return {
-            "totsym": self.totsym_number.get_value(),
+            "total_symmetry": self.totsym_number.get_value(),
             "ras1_max_hole": self.ras1_max_hole_number.get_value(),
             "ras3_max_electron": self.ras3_max_electron_number.get_value(),
             "dirac_ver": self.dirac_ver_number.get_value(),


### PR DESCRIPTION
- use this key when this program loads settings.json